### PR TITLE
roll back version number to v0.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OhMyThreads"
 uuid = "67456a42-1dca-4109-a031-0a68de7e3ad5"
 authors = ["Mason Protter <mason.protter@icloud.com>"]
-version = "0.2.2"
+version = "0.2.0"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"


### PR DESCRIPTION
I tagged a bunch of versions forgetting it wasn't on the general registry yet. We'll keep this at v0.2.0 until it's actually registered.