### PR TITLE
Reject unsupported kwargs early

### DIFF
--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -15,6 +15,11 @@ function tmapreduce(f, op, Arrs...;
     schedule::Symbol=:dynamic,
     outputtype::Type=Any,
     mapreduce_kwargs...)
+
+    min_kwarg_len = haskey(mapreduce_kwargs, :init) ? 1 : 0
+    if length(mapreduce_kwargs) > min_kwarg_len
+        tmapreduce_kwargs_err(;mapreduce_kwargs...)
+    end
     if schedule === :dynamic 
         _tmapreduce(f, op, Arrs, outputtype, nchunks, split, :default, mapreduce_kwargs)
     elseif schedule === :interactive
@@ -28,6 +33,10 @@ function tmapreduce(f, op, Arrs...;
     end
 end
 @noinline schedule_err(s) = error(ArgumentError("Invalid schedule option: $s, expected :dynamic, :interactive, :greedy, or :static."))
+
+@noinline function tmapreduce_kwargs_err(;init=nothing, kwargs...)
+    error("got unsupported keyword arguments: $((;kwargs...,)) ")
+end
 
 treducemap(op, f, A...; kwargs...) = tmapreduce(f, op, A...; kwargs...)
 


### PR DESCRIPTION
<details><summary> Before </summary>
<p>

```julia
julia> tmapreduce(sin, +, 1:100; asdasb=1)
ERROR: TaskFailedException
Stacktrace:
 [1] wait
   @ ./task.jl:352 [inlined]
 [2] fetch
   @ ./task.jl:372 [inlined]
 [3] fetch(t::StableTasks.StableTask{Union{}})
   @ StableTasks.Internals ~/.julia/packages/StableTasks/8197D/src/internals.jl:9
 [4] _mapreduce(f::typeof(fetch), op::typeof(+), ::IndexLinear, A::Vector{StableTasks.StableTask{Union{}}})
   @ Base ./reduce.jl:440
 [5] _mapreduce_dim(f::Function, op::Function, ::Base._InitialValue, A::Vector{StableTasks.StableTask{Union{}}}, ::Colon)
   @ Base ./reducedim.jl:365
 [6] mapreduce(f::Function, op::Function, A::Vector{StableTasks.StableTask{Union{}}})
   @ Base ./reducedim.jl:357
 [7] _tmapreduce(f::Function, op::Function, Arrs::Tuple{…}, ::Type{…}, nchunks::Int64, split::Symbol, threadpool::Symbol, mapreduce_kwargs::@Kwargs{…})
   @ OhMyThreads.Implementation ~/Dropbox/Julia/OhMyThreads/src/implementation.jl:40
 [8] #tmapreduce#101
   @ OhMyThreads.Implementation ~/Dropbox/Julia/OhMyThreads/src/implementation.jl:19 [inlined]
 [9] top-level scope
   @ REPL[9]:1

    nested task error: MethodError: no method matching mapreduce(::typeof(sin), ::typeof(+), ::StepRange{Int64, Int64}; asdasb::Int64)
    
    Closest candidates are:
      mapreduce(::Any, ::Any, ::Union{Base.AbstractBroadcasted, AbstractArray}; dims, init) got unsupported keyword argument "asdasb"
       @ Base reducedim.jl:357
      mapreduce(::Any, ::Any, ::Union{Base.AbstractBroadcasted, AbstractArray}...; kw...)
       @ Base reducedim.jl:359
      mapreduce(::Any, ::Any, ::Any; kw...)
       @ Base reduce.jl:307
      ...
    
    Stacktrace:
     [1] kwerr(::@NamedTuple{asdasb::Int64}, ::Function, ::Function, ::Function, ::StepRange{Int64, Int64})
       @ Base ./error.jl:165
     [2] (::OhMyThreads.Implementation.var"#6#10"{Tuple{StepRange{…}}, @Kwargs{asdasb::Int64}, typeof(sin), typeof(+)})()
       @ OhMyThreads.Implementation ~/Dropbox/Julia/OhMyThreads/src/implementation.jl:47
     [3] (::OhMyThreads.Implementation.var"#7#11"{StableTasks.AtomicRef{…}, OhMyThreads.Implementation.var"#6#10"{…}})()
       @ OhMyThreads.Implementation ~/.julia/packages/StableTasks/8197D/src/internals.jl:67
Some type information was truncated. Use `show(err)` to see complete types.
```

</details>
</p>

<details><summary> After </summary>
<p>

```julia
julia> tmapreduce(sin, +, 1:100; asdasb=1)
ERROR: got unsupported keyword arguments: (asdasb = 1,) 
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] kwargs_err(; init::Nothing, kwargs::@Kwargs{asdasb::Int64})
   @ OhMyThreads.Implementation ~/Dropbox/Julia/OhMyThreads/src/implementation.jl:38
 [3] tmapreduce(f::Function, op::Function, Arrs::UnitRange{…}; nchunks::Int64, split::Symbol, schedule::Symbol, outputtype::Type, mapreduce_kwargs::@Kwargs{…})
   @ OhMyThreads.Implementation ~/Dropbox/Julia/OhMyThreads/src/implementation.jl:21
 [4] top-level scope
   @ REPL[5]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

</details>
</p>
