### PR TITLE
Add GH action to enforce CHANGELOG.md updates for PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,12 @@
+name: changelog
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  # Can be skipped with the `Skip-Changelog` label
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dangoslen/changelog-enforcer@v3


### PR DESCRIPTION
Can be skipped by giving a PR the "Skip-Changelog".