### PR TITLE
Schedulers as `struct`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Version 0.4.0
 -------------
 
 - ![BREAKING][badge-breaking] Instead of taking keyword arguments `schedule`, `nchunks`, `split` directly, we now use `Scheduler` structs to specify scheduling options ([#22](https://github.com/JuliaFolds2/OhMyThreads.jl/issues/22)). The latter can be provided to all API functions via the new `scheduler` keyword argument.
-- ![BREAKING][badge-breaking] The default scheduler (`DynamicScheduler`) now, by default, creates `2*nthreads()` tasks to provide load-balancing by default. The old behavior can be restored with `DynamicScheduler(nchunks=nthreads())`.
+- ![BREAKING][badge-breaking] The default scheduler (`DynamicScheduler`) now, by default, creates `2*nthreads()` tasks to provide load-balancing by default. The old behavior can be restored with `DynamicScheduler(; nchunks=nthreads())`.
 - ![Enhancement][badge-enhancement] We reject unsupported keyword arguments early and give a more helpful error message.
 
 Version 0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 OhMyThreads.jl Changelog
 =========================
 
-Version X.X.X
+Version 0.4.0
 -------------
 
+- ![BREAKING][badge-breaking] Instead of taking keyword arguments `schedule`, `nchunks`, `split` directly, we now use `Scheduler` structs to specify scheduling options ([#22](https://github.com/JuliaFolds2/OhMyThreads.jl/issues/22)). The latter can be provided to all API functions via the new `scheduler` keyword argument.
 - ![Enhancement][badge-enhancement] We reject unsupported keyword arguments early and give a more helpful error message.
 
 Version 0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 0.4.0
 -------------
 
 - ![BREAKING][badge-breaking] Instead of taking keyword arguments `schedule`, `nchunks`, `split` directly, we now use `Scheduler` structs to specify scheduling options ([#22](https://github.com/JuliaFolds2/OhMyThreads.jl/issues/22)). The latter can be provided to all API functions via the new `scheduler` keyword argument.
+- ![BREAKING][badge-breaking] The default scheduler (`DynamicScheduler`) now, by default, creates `2*nthreads()` tasks to provide load-balancing by default. The old behavior can be restored with `DynamicScheduler(nchunks=nthreads())`.
 - ![Enhancement][badge-enhancement] We reject unsupported keyword arguments early and give a more helpful error message.
 
 Version 0.3.1

--- a/README.md
+++ b/README.md
@@ -55,17 +55,17 @@ mc_parallel(N) # gives, e.g., 3.14159924
 
 using BenchmarkTools
 
-@show Threads.nthreads()          # 5 in this example
+@show Threads.nthreads()                                        # 5 in this example
 
-@btime mc_parallel($N; nchunks=1) # effectively running with a single Julia thread
-@btime mc_parallel($N)            # running with all 5 Julia threads
+@btime mc_parallel($N; scheduler=DynamicScheduler(nchunks=1))   # effectively using 1 thread
+@btime mc_parallel($N)                                          # using all 5 threads
 ```
 
 Timings might be something like this:
 
 ```
-438.394 ms (7 allocations: 624 bytes)
-88.050 ms (37 allocations: 3.02 KiB)
+447.093 ms (7 allocations: 624 bytes)
+89.401 ms (66 allocations: 5.72 KiB)
 ```
 
 (Check out the full [Parallel Monte Carlo](https://juliafolds2.github.io/OhMyThreads.jl/stable/examples/mc/mc/) example if you like.)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ using BenchmarkTools
 
 @show Threads.nthreads()                                        # 5 in this example
 
-@btime mc_parallel($N; scheduler=DynamicScheduler(nchunks=1))   # effectively using 1 thread
+@btime mc_parallel($N; scheduler=DynamicScheduler(; nchunks=1))   # effectively using 1 thread
 @btime mc_parallel($N)                                          # using all 5 threads
 ```
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,15 +12,11 @@ makedocs(;
     doctest = false,
     pages = [
         "OhMyThreads" => "index.md",
-        # "Getting Started" => "getting_started.md",
          "Examples" => [
              "Parallel Monte Carlo" => "examples/mc/mc.md",
              "Julia Set" => "examples/juliaset/juliaset.md",
              "Trapezoidal Integration" => "examples/integration/integration.md",
          ],
-        #  "Explanations" => [
-        #      "B" => "explanations/B.md",
-        #  ],
         "Translation Guide" => "translation.md",
         "Task-Local Storage" => "examples/tls/tls.md",
         "API" => [

--- a/docs/src/examples/integration/integration.jl
+++ b/docs/src/examples/integration/integration.jl
@@ -30,6 +30,7 @@ end
 
 using Base.Threads: nthreads
 @show nthreads()
+
 N = nthreads() * 1_000_000
 
 # Calling `trapezoidal` we do indeed find the (approximate) value of $\pi$.

--- a/docs/src/examples/integration/integration.md
+++ b/docs/src/examples/integration/integration.md
@@ -47,6 +47,7 @@ interval, as a multiple of the number of available Julia threads.
 ````julia
 using Base.Threads: nthreads
 @show nthreads()
+
 N = nthreads() * 1_000_000
 ````
 
@@ -110,8 +111,8 @@ using BenchmarkTools
 ````
 
 ````
-  13.871 ms (0 allocations: 0 bytes)
-  2.781 ms (38 allocations: 3.19 KiB)
+  12.782 ms (0 allocations: 0 bytes)
+  2.563 ms (37 allocations: 3.16 KiB)
 
 ````
 

--- a/docs/src/examples/juliaset/juliaset.jl
+++ b/docs/src/examples/juliaset/juliaset.jl
@@ -86,23 +86,32 @@ using Base.Threads: nthreads
 N = 2000
 img = zeros(Int, N, N)
 
+@show nthreads()
+
 @btime compute_juliaset_sequential!($img) samples=10 evals=3;
 @btime compute_juliaset_parallel!($img) samples=10 evals=3;
 
-# As hoped, the parallel implementation is faster. But can we improve the performance
-# further?
+# As hoped, the parallel implementation is much faster!
 
-# ### Tuning `nchunks`
+# ### Dynamic vs static scheduling
 #
-# As stated above, the per-pixel computation is non-uniform. Hence, we might benefit from
-# load balancing. The simplest way to get it is to increase `nchunks` to a value larger
-# than `nthreads`. This divides the overall workload into smaller tasks than can be
-# dynamically distributed among threads (by Julia's scheduler) to balance the per-thread
-# load.
+# As stated above, the per-pixel computation is non-uniform. Hence, we do benefit from
+# the load balancing of the default dynamic scheduler. The latter divides the overall
+# workload into tasks that can then be dynamically distributed among threads to adjust the
+# per-thread load. We can try to fine tune and improve the load balancing further by
+# increasing the `nchunks` parameter of the scheduler, that is, creating more and smaller
+# tasks.
 
-@btime compute_juliaset_parallel!($img; schedule=:dynamic, nchunks=N) samples=10 evals=3;
+using OhMyThreads: DynamicScheduler
 
-# Note that if we opt out of dynamic scheduling and set `schedule=:static`, this strategy
-# doesn't help anymore (because chunks are naively distributed up front).
+@btime compute_juliaset_parallel!($img; scheduler=DynamicScheduler(nchunks=N)) samples=10 evals=3;
 
-@btime compute_juliaset_parallel!($img; schedule=:static, nchunks=N) samples=10 evals=3;
+# Note that while this turns out to be a bit faster, it comes at the expense of much more
+# allocations.
+#
+# To quantify the impact of load balancing we can opt out of dynamic scheduling and use the
+# `StaticScheduler` instead. The latter doesn't provide any form of load balancing.
+
+using OhMyThreads: StaticScheduler
+
+@btime compute_juliaset_parallel!($img; scheduler=StaticScheduler()) samples=10 evals=3;

--- a/docs/src/examples/juliaset/juliaset.jl
+++ b/docs/src/examples/juliaset/juliaset.jl
@@ -104,7 +104,7 @@ img = zeros(Int, N, N)
 
 using OhMyThreads: DynamicScheduler
 
-@btime compute_juliaset_parallel!($img; scheduler=DynamicScheduler(nchunks=N)) samples=10 evals=3;
+@btime compute_juliaset_parallel!($img; scheduler=DynamicScheduler(; nchunks=N)) samples=10 evals=3;
 
 # Note that while this turns out to be a bit faster, it comes at the expense of much more
 # allocations.

--- a/docs/src/examples/juliaset/juliaset.md
+++ b/docs/src/examples/juliaset/juliaset.md
@@ -129,7 +129,7 @@ tasks.
 ````julia
 using OhMyThreads: DynamicScheduler
 
-@btime compute_juliaset_parallel!($img; scheduler=DynamicScheduler(nchunks=N)) samples=10 evals=3;
+@btime compute_juliaset_parallel!($img; scheduler=DynamicScheduler(; nchunks=N)) samples=10 evals=3;
 ````
 
 ````

--- a/docs/src/examples/tls/tls.jl
+++ b/docs/src/examples/tls/tls.jl
@@ -124,7 +124,7 @@ using Base.Threads: nthreads
 
 function matmulsums_manual(As, Bs)
     N = size(first(As), 1)
-    tasks = map(chunks(As; n = nthreads())) do idcs
+    tasks = map(chunks(As; n = 2 * nthreads())) do idcs
         @spawn begin
             local C = Matrix{Float64}(undef, N, N)
             local results = Vector{Float64}(undef, length(idcs))
@@ -143,7 +143,7 @@ res ≈ res_manual
 
 # The first thing to note is pretty obvious: This is very cumbersome and you probably don't
 # want to write it. But let's take a closer look and see what's happening here.
-# First, we divide the number of matrix pairs into `nthreads()` chunks. Then, for each of
+# First, we divide the number of matrix pairs into `2 * nthreads()` chunks. Then, for each of
 # those chunks, we spawn a parallel task that (1) allocates a task-local `C` matrix (and a
 # `results` vector) and (2) performs the actual computations using these pre-allocated
 # values. Finally, we `fetch` the results of the tasks and combine them.
@@ -163,5 +163,26 @@ using BenchmarkTools
 @btime matmulsums_manual($As, $Bs);
 
 # As we see, the recommened version `matmulsums_tls` is both convenient as well as
-# efficient: It allocates much less memory than `matmulsums_naive` (5 vs 64 times 8 MiB)
+# efficient: It allocates much less memory than `matmulsums_naive` (10 vs 64 times 8 MiB)
 # and is very much comparable to the manual implementation.
+
+# ### Tuning the scheduling
+#
+# Since the workload is uniform, we don't need load balancing. We can thus try to use
+# `DynamicScheduler(nchunks=nthreads())` and `StaticScheduler()` to improve the performance
+# and/or reduce the number of allocations.
+
+using OhMyThreads: DynamicScheduler, StaticScheduler
+
+function matmulsums_tls_kwargs(As, Bs; kwargs...)
+    N = size(first(As), 1)
+    tls = TaskLocalValue{Matrix{Float64}}(() -> Matrix{Float64}(undef, N, N))
+    tmap(As, Bs; kwargs...) do A, B
+        C = tls[]
+        mul!(C, A, B)
+        sum(C)
+    end
+end
+
+@btime matmulsums_tls_kwargs($As, $Bs; scheduler=$(DynamicScheduler(nchunks=nthreads())));
+@btime matmulsums_tls_kwargs($As, $Bs; scheduler=$(StaticScheduler()));

--- a/docs/src/examples/tls/tls.jl
+++ b/docs/src/examples/tls/tls.jl
@@ -169,7 +169,7 @@ using BenchmarkTools
 # ### Tuning the scheduling
 #
 # Since the workload is uniform, we don't need load balancing. We can thus try to use
-# `DynamicScheduler(nchunks=nthreads())` and `StaticScheduler()` to improve the performance
+# `DynamicScheduler(; nchunks=nthreads())` and `StaticScheduler()` to improve the performance
 # and/or reduce the number of allocations.
 
 using OhMyThreads: DynamicScheduler, StaticScheduler
@@ -184,5 +184,5 @@ function matmulsums_tls_kwargs(As, Bs; kwargs...)
     end
 end
 
-@btime matmulsums_tls_kwargs($As, $Bs; scheduler=$(DynamicScheduler(nchunks=nthreads())));
+@btime matmulsums_tls_kwargs($As, $Bs; scheduler=$(DynamicScheduler(; nchunks=nthreads())));
 @btime matmulsums_tls_kwargs($As, $Bs; scheduler=$(StaticScheduler()));

--- a/docs/src/examples/tls/tls.jl
+++ b/docs/src/examples/tls/tls.jl
@@ -1,4 +1,4 @@
-# # Task-Local Storage
+# # [Task-Local Storage](@id TLS)
 #
 # For some programs, it can be useful or even necessary to allocate and (re-)use memory in
 # your parallel code. The following section uses a simple example to explain how task-local

--- a/docs/src/examples/tls/tls.md
+++ b/docs/src/examples/tls/tls.md
@@ -233,7 +233,7 @@ and is very much comparable to the manual implementation.
 ### Tuning the scheduling
 
 Since the workload is uniform, we don't need load balancing. We can thus try to use
-`DynamicScheduler(nchunks=nthreads())` and `StaticScheduler()` to improve the performance
+`DynamicScheduler(; nchunks=nthreads())` and `StaticScheduler()` to improve the performance
 and/or reduce the number of allocations.
 
 ````julia
@@ -249,7 +249,7 @@ function matmulsums_tls_kwargs(As, Bs; kwargs...)
     end
 end
 
-@btime matmulsums_tls_kwargs($As, $Bs; scheduler=$(DynamicScheduler(nchunks=nthreads())));
+@btime matmulsums_tls_kwargs($As, $Bs; scheduler=$(DynamicScheduler(; nchunks=nthreads())));
 @btime matmulsums_tls_kwargs($As, $Bs; scheduler=$(StaticScheduler()));
 ````
 

--- a/docs/src/examples/tls/tls.md
+++ b/docs/src/examples/tls/tls.md
@@ -2,7 +2,7 @@
 EditURL = "tls.jl"
 ```
 
-# Task-Local Storage
+# [Task-Local Storage](@id TLS)
 
 For some programs, it can be useful or even necessary to allocate and (re-)use memory in
 your parallel code. The following section uses a simple example to explain how task-local

--- a/docs/src/examples/tomarkdown.sh
+++ b/docs/src/examples/tomarkdown.sh
@@ -27,6 +27,7 @@ for d in dirs
     println("directory: ", d)
     cd(d) do
         Pkg.activate(".")
+        Pkg.resolve()
         Pkg.instantiate()
         jlfiles = filter(endswith(".jl"), readdir())
         for f in jlfiles

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,17 +29,17 @@ mc_parallel(N) # gives, e.g., 3.14159924
 
 using BenchmarkTools
 
-@show Threads.nthreads()          # 5 in this example
+@show Threads.nthreads()                                        # 5 in this example
 
-@btime mc_parallel($N; nchunks=1) # effectively running with a single Julia thread
-@btime mc_parallel($N)            # running with all 5 Julia threads
+@btime mc_parallel($N; scheduler=DynamicScheduler(nchunks=1))   # effectively using 1 thread
+@btime mc_parallel($N)                                          # using all 5 threads
 ```
 
 Timings might be something like this:
 
 ```
-438.394 ms (7 allocations: 624 bytes)
-88.050 ms (37 allocations: 3.02 KiB)
+447.093 ms (7 allocations: 624 bytes)
+89.401 ms (66 allocations: 5.72 KiB)
 ```
 
 (Check out the full [Parallel Monte Carlo](@ref) example if you like.)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -31,7 +31,7 @@ using BenchmarkTools
 
 @show Threads.nthreads()                                        # 5 in this example
 
-@btime mc_parallel($N; scheduler=DynamicScheduler(nchunks=1))   # effectively using 1 thread
+@btime mc_parallel($N; scheduler=DynamicScheduler(; nchunks=1))   # effectively using 1 thread
 @btime mc_parallel($N)                                          # using all 5 threads
 ```
 

--- a/docs/src/refs/api.md
+++ b/docs/src/refs/api.md
@@ -4,10 +4,12 @@
 
 ```@index
 Pages   = ["api.md"]
-Order   = [:function, :macro]
+Order   = [:function, :macro, :type]
 ```
 
 ## Exported
+
+### Functions
 
 ```@docs
 tmapreduce
@@ -17,6 +19,15 @@ tmap!
 tforeach
 tcollect
 treducemap
+```
+
+### Schedulers
+
+```@docs
+Scheduler
+DynamicScheduler
+StaticScheduler
+GreedyScheduler
 ```
 
 ## Non-Exported

--- a/docs/src/translation.md
+++ b/docs/src/translation.md
@@ -47,7 +47,7 @@ end
 
 ```julia
 # OhMyThreads
-tforeach(1:10; scheduler=DynamicScheduler(nchunks=10)) do i
+tforeach(1:10; scheduler=DynamicScheduler(; nchunks=10)) do i
     println(i)
 end
 ```

--- a/docs/src/translation.md
+++ b/docs/src/translation.md
@@ -31,7 +31,7 @@ end
 
 ```julia
 # OhMyThreads
-tforeach(1:10; schedule=:static) do i
+tforeach(1:10; scheduler=StaticScheduler()) do i
     println(i)
 end
 ```
@@ -47,7 +47,7 @@ end
 
 ```julia
 # OhMyThreads
-tforeach(1:10; nchunks=10) do i
+tforeach(1:10; scheduler=DynamicScheduler(nchunks=10)) do i
     println(i)
 end
 ```

--- a/src/OhMyThreads.jl
+++ b/src/OhMyThreads.jl
@@ -1,11 +1,8 @@
 module OhMyThreads
 
-
 using StableTasks: StableTasks, @spawn, @spawnat
 using ChunkSplitters: ChunkSplitters, chunks
 using TaskLocalValues: TaskLocalValues, TaskLocalValue
-
-export treduce, tmapreduce, treducemap, tmap, tmap!, tforeach, tcollect
 
 """
     tmapreduce(f, op, A::AbstractArray...;
@@ -281,7 +278,12 @@ To see the keyword argument options, check out `??tcollect`.
 function tcollect end
 
 include("tools.jl")
+include("schedulers.jl")
+using .Schedulers: Scheduler, DynamicScheduler, StaticScheduler, GreedyScheduler
 include("implementation.jl")
 
+
+export treduce, tmapreduce, treducemap, tmap, tmap!, tforeach, tcollect
+export Scheduler, DynamicScheduler, StaticScheduler, GreedyScheduler
 
 end # module OhMyThreads

--- a/src/OhMyThreads.jl
+++ b/src/OhMyThreads.jl
@@ -6,11 +6,9 @@ using TaskLocalValues: TaskLocalValues, TaskLocalValue
 
 """
     tmapreduce(f, op, A::AbstractArray...;
-               [init],
-               nchunks::Int = nthreads(),
-               split::Symbol = :batch,
-               schedule::Symbol =:dynamic,
-               outputtype::Type = Any)
+               [scheduler::Scheduler = DynamicScheduler()],
+               [outputtype::Type = Any],
+               [init])
 
 A multithreaded function like `Base.mapreduce`. Perform a reduction over `A`, applying a
 single-argument function `f` to each element, and then combining them with the two-argument
@@ -21,43 +19,31 @@ Note that `op` **must** be an
 that `op(a, op(b, c)) ≈ op(op(a, b), c)`. If `op` is not (approximately) associative, you
 will get undefined results.
 
-For parallelization, the data is divided into chunks and a parallel task is created per
-chunk.
-
-To see the keyword argument options, check out `??tmapreduce`.
-
 ## Example:
 
-     tmapreduce(√, +, [1, 2, 3, 4, 5])
+```
+tmapreduce(√, +, [1, 2, 3, 4, 5])
+```
 
 is the parallelized version of `sum(√, [1, 2, 3, 4, 5])` in the form
 
-     (√1 + √2) + (√3 + √4) + √5
-
-# Extended help
+```
+(√1 + √2) + (√3 + √4) + √5
+```
 
 ## Keyword arguments:
 
-- `init` optional keyword argument forwarded to `mapreduce` for the sequential parts of the calculation.
-- `nchunks::Int` (default `nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
-- `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
-- `schedule::Symbol` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. Options are one of
-    - `:dynamic`: generally preferred since it is more flexible and better at load balancing, and won't interfere with other multithreaded functions which may be running on the system.
-    - `:static`: can sometimes be more performant than `:dynamic` when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
-    - `:greedy`: best option for load-balancing slower, uneven computations, but does carry some additional overhead. This schedule will read from the contents of `A` in a non-deterministic order, and thus your reducing `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results! This schedule will however work with non-`AbstractArray` iterables. If you use the `:greedy` scheduler, we strongly recommend you provide an `init` keyword argument.
-    - `:interactive`: like `:dynamic` but runs on the high-priority interactive threadpool. This should be used very carefully since tasks on this threadpool should not be allowed to run for a long time without `yield`ing as it can interfere with [heartbeat](https://en.wikipedia.org/wiki/Heartbeat_(computing)) processes running on the interactive threadpool.
-- `outputtype::Type` (default `Any`) will work as the asserted output type of parallel calculations. This is typically only
-needed if you are using a `:static` schedule, since the `:dynamic` schedule is uses [StableTasks.jl](https://github.com/MasonProtter/StableTasks.jl), but if you experience problems with type stability, you may be able to recover it with the `outputtype` keyword argument.
+- `scheduler::Scheduler` (default `DynamicScheduler()`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information.
+- `outputtype::Type` (default `Any`): will work as the asserted output type of parallel calculations. We use [StableTasks.jl](https://github.com/MasonProtter/StableTasks.jl) to make setting this option unnecessary, but if you experience problems with type stability, you may be able to recover it with this keyword argument.
+- `init`: forwarded to `mapreduce` for the task-local sequential parts of the calculation.
 """
 function tmapreduce end
 
 """
     treducemap(op, f, A::AbstractArray...;
-               [init],
-               nchunks::Int = nthreads(),
-               split::Symbol = :batch,
-               schedule::Symbol =:dynamic,
-               outputtype::Type = Any)
+               [scheduler::Scheduler = DynamicScheduler()],
+               [outputtype::Type = Any],
+               [init])
 
 Like `tmapreduce` except the order of the `f` and `op` arguments are switched. This is
 sometimes convenient with `do`-block notation. Perform a reduction over `A`, applying a
@@ -69,44 +55,31 @@ Note that `op` **must** be an
 that `op(a, op(b, c)) ≈ op(op(a, b), c)`. If `op` is not (approximately) associative, you
 will get undefined results.
 
-For parallelization, the data is divided into chunks and a parallel task is created per
-chunk.
-
-To see the keyword argument options, check out `??treducemap`.
-
 ## Example:
 
-     tmapreduce(√, +, [1, 2, 3, 4, 5])
+```
+tmapreduce(√, +, [1, 2, 3, 4, 5])
+```
 
 is the parallelized version of `sum(√, [1, 2, 3, 4, 5])` in the form
 
-     (√1 + √2) + (√3 + √4) + √5
-
-# Extended help
+```
+(√1 + √2) + (√3 + √4) + √5
+```
 
 ## Keyword arguments:
 
-- `init` optional keyword argument forwarded to `mapreduce` for the sequential parts of the calculation.
-- `nchunks::Int` (default `nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
-- `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
-- `schedule::Symbol` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. Options are one of
-    - `:dynamic`: generally preferred since it is more flexible and better at load balancing, and won't interfere with other multithreaded functions which may be running on the system.
-    - `:static`: can sometimes be more performant than `:dynamic` when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
-    - `:greedy`: best option for load-balancing slower, uneven computations, but does carry some additional overhead. This schedule will read from the contents of `A` in a non-deterministic order, and thus your reducing `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results! This schedule will however work with non-`AbstractArray` iterables. If you use the `:greedy` scheduler, we strongly recommend you provide an `init` keyword argument.
-    - `:interactive`: like `:dynamic` but runs on the high-priority interactive threadpool. This should be used very carefully since tasks on this threadpool should not be allowed to run for a long time without `yield`ing as it can interfere with [heartbeat](https://en.wikipedia.org/wiki/Heartbeat_(computing)) processes running on the interactive threadpool.
-- `outputtype::Type` (default `Any`) will work as the asserted output type of parallel calculations. This is typically only
-needed if you are using a `:static` schedule, since the `:dynamic` schedule is uses [StableTasks.jl](https://github.com/MasonProtter/StableTasks.jl), but if you experience problems with type stability, you may be able to recover it with the `outputtype` keyword argument.
+- `scheduler::Scheduler` (default `DynamicScheduler()`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information.
+- `outputtype::Type` (default `Any`): will work as the asserted output type of parallel calculations. We use [StableTasks.jl](https://github.com/MasonProtter/StableTasks.jl) to make setting this option unnecessary, but if you experience problems with type stability, you may be able to recover it with this keyword argument.
+- `init`: forwarded to `mapreduce` for the task-local sequential parts of the calculation.
 """
 function treducemap end
 
-
 """
     treduce(op, A::AbstractArray...;
-            [init],
-            nchunks::Int = nthreads(),
-            split::Symbol = :batch,
-            schedule::Symbol =:dynamic,
-            outputtype::Type = Any)
+            [scheduler::Scheduler = DynamicScheduler()],
+            [outputtype::Type = Any],
+            [init])
 
 A multithreaded function like `Base.reduce`. Perform a reduction over `A` using the
 two-argument function `op`.
@@ -116,140 +89,92 @@ Note that `op` **must** be an
 that `op(a, op(b, c)) ≈ op(op(a, b), c)`. If `op` is not (approximately) associative, you
 will get undefined results.
 
-For parallelization, the data is divided into chunks and a parallel task is created per
-chunk.
-
-To see the keyword argument options, check out `??treduce`.
-
 ## Example:
 
-        treduce(+, [1, 2, 3, 4, 5])
+```
+treduce(+, [1, 2, 3, 4, 5])
+```
 
 is the parallelized version of `sum([1, 2, 3, 4, 5])` in the form
 
-        (1 + 2) + (3 + 4) + 5
-
-# Extended help
+```
+(1 + 2) + (3 + 4) + 5
+```
 
 ## Keyword arguments:
 
-- `init` optional keyword argument forwarded to `mapreduce` for the sequential parts of the calculation.
-- `nchunks::Int` (default `nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
-- `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
-- `schedule::Symbol` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. Options are one of
-    - `:dynamic`: generally preferred since it is more flexible and better at load balancing, and won't interfere with other multithreaded functions which may be running on the system.
-    - `:static`: can sometimes be more performant than `:dynamic` when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
-    - `:greedy`: best option for load-balancing slower, uneven computations, but does carry some additional overhead. This schedule will read from the contents of `A` in a non-deterministic order, and thus your reducing `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results! This schedule will however work with non-`AbstractArray` iterables. If you use the `:greedy` scheduler, we strongly recommend you provide an `init` keyword argument.
-    - `:interactive`: like `:dynamic` but runs on the high-priority interactive threadpool. This should be used very carefully since tasks on this threadpool should not be allowed to run for a long time without `yield`ing as it can interfere with [heartbeat](https://en.wikipedia.org/wiki/Heartbeat_(computing)) processes running on the interactive threadpool.
-- `outputtype::Type` (default `Any`) will work as the asserted output type of parallel calculations. This is typically only
-needed if you are using a `:static` schedule, since the `:dynamic` schedule is uses [StableTasks.jl](https://github.com/MasonProtter/StableTasks.jl), but if you experience problems with type stability, you may be able to recover it with the `outputtype` keyword argument.
+- `scheduler::Scheduler` (default `DynamicScheduler()`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information.
+- `outputtype::Type` (default `Any`): will work as the asserted output type of parallel calculations. We use [StableTasks.jl](https://github.com/MasonProtter/StableTasks.jl) to make setting this option unnecessary, but if you experience problems with type stability, you may be able to recover it with this keyword argument.
+- `init`: forwarded to `mapreduce` for the task-local sequential parts of the calculation.
 """
 function treduce end
 
 """
     tforeach(f, A::AbstractArray...;
-             nchunks::Int = nthreads(),
-             split::Symbol = :batch,
-             schedule::Symbol =:dynamic) :: Nothing
+             [schedule::Scheduler = DynamicScheduler()]) :: Nothing
 
 A multithreaded function like `Base.foreach`. Apply `f` to each element of `A` on
 multiple parallel tasks, and return `nothing`. I.e. it is the parallel equivalent of
 
-    for x in A
-        f(x)
-    end
-
-For parallelization, the data is divided into chunks and a parallel task is created per
-chunk.
-
-To see the keyword argument options, check out `??tforeach`.
+```
+for x in A
+    f(x)
+end
+```
 
 ## Example:
 
-        tforeach(1:10) do i
-            println(i^2)
-        end
-
-# Extended help
+```
+tforeach(1:10) do i
+    println(i^2)
+end
+```
 
 ## Keyword arguments:
 
-- `nchunks::Int` (default `nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
-- `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
-- `schedule::Symbol` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. Options are one of
-    - `:dynamic`: generally preferred since it is more flexible and better at load balancing, and won't interfere with other multithreaded functions which may be running on the system.
-    - `:static`: can sometimes be more performant than `:dynamic` when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
-    - `:greedy`: best option for load-balancing slower, uneven computations, but does carry some additional overhead.
-    - `:interactive`: like `:dynamic` but runs on the high-priority interactive threadpool. This should be used very carefully since tasks on this threadpool should not be allowed to run for a long time without `yield`ing as it can interfere with [heartbeat](https://en.wikipedia.org/wiki/Heartbeat_(computing)) processes running on the interactive threadpool.
+- `scheduler::Scheduler` (default `DynamicScheduler()`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information.
 """
 function tforeach end
 
 """
     tmap(f, [OutputElementType], A::AbstractArray...;
-         nchunks::Int = nthreads(),
-         split::Symbol = :batch,
-         schedule::Symbol =:dynamic)
+         [schedule::Scheduler = DynamicScheduler()])
 
-A multithreaded function like `Base.map`. Create a new container `similar` to `A` whose
-`i`th element is equal to `f(A[i])`. This container is filled in parallel: the data is
-divided into chunks and a parallel task is created per chunk.
+A multithreaded function like `Base.map`. Create a new container `similar` to `A` and fills
+it in parallel such that the `i`th element is equal to `f(A[i])`.
 
 The optional argument `OutputElementType` will select a specific element type for the
 returned container, and will generally incur fewer allocations than the version where
 `OutputElementType` is not specified.
 
-To see the keyword argument options, check out `??tmap`.
-
 ## Example:
 
-        tmap(sin, 1:10)
-
-# Extended help
+```
+tmap(sin, 1:10)
+```
 
 ## Keyword arguments:
 
-- `nchunks::Int` (default `nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
-- `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
-- `schedule::Symbol` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. Options are one of
-    - `:dynamic`: generally preferred since it is more flexible and better at load balancing, and won't interfere with other multithreaded functions which may be running on the system.
-    - `:static`: can sometimes be more performant than `:dynamic` when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
-    - `:greedy`: best option for load-balancing slower, uneven computations, but does carry some additional overhead. This schedule only works if the `OutputElementType` argument is provided.
-    - `:interactive`: like `:dynamic` but runs on the high-priority interactive threadpool. This should be used very carefully since tasks on this threadpool should not be allowed to run for a long time without `yield`ing as it can interfere with [heartbeat](https://en.wikipedia.org/wiki/Heartbeat_(computing)) processes running on the interactive threadpool.
+- `scheduler::Scheduler` (default `DynamicScheduler()`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information.
 """
 function tmap end
 
 """
     tmap!(f, out, A::AbstractArray...;
-          nchunks::Int = nthreads(),
-          split::Symbol = :batch,
-          schedule::Symbol =:dynamic)
+          [schedule::Scheduler = DynamicScheduler()])
 
 A multithreaded function like `Base.map!`. In parallel on multiple tasks, this function
 assigns each element of `out[i] = f(A[i])` for each index `i` of `A` and `out`.
 
-For parallelization, the data is divided into chunks and a parallel task is created per
-chunk.
-
-To see the keyword argument options, check out `??tmap!`.
-
-# Extended help
-
 ## Keyword arguments:
 
-- `nchunks::Int` (default `nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
-- `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
-- `schedule::Symbol` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. Options are one of
-    - `:dynamic`: generally preferred since it is more flexible and better at load balancing, and won't interfere with other multithreaded functions which may be running on the system.
-    - `:static`: can sometimes be more performant than `:dynamic` when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
-    - `:greedy`: best option for load-balancing slower, uneven computations, but does carry some additional overhead.
-    - `:interactive`: like `:dynamic` but runs on the high-priority interactive threadpool. This should be used very carefully since tasks on this threadpool should not be allowed to run for a long time without `yield`ing as it can interfere with [heartbeat](https://en.wikipedia.org/wiki/Heartbeat_(computing)) processes running on the interactive threadpool.
+- `scheduler::Scheduler` (default `DynamicScheduler()`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information.
 """
 function tmap! end
 
 """
     tcollect([OutputElementType], gen::Union{AbstractArray, Generator{<:AbstractArray}};
-             nchunks::Int = nthreads(),
-             schedule::Symbol =:dynamic)
+             [schedule::Scheduler = DynamicScheduler()])
 
 A multithreaded function like `Base.collect`. Essentially just calls `tmap` on the
 generator function and inputs.
@@ -258,22 +183,15 @@ The optional argument `OutputElementType` will select a specific element type fo
 returned container, and will generally incur fewer allocations than the version where
 `OutputElementType` is not specified.
 
-To see the keyword argument options, check out `??tcollect`.
-
 ## Example:
 
-        tcollect(sin(i) for i in 1:10)
-
-# Extended help
+```
+tcollect(sin(i) for i in 1:10)
+```
 
 ## Keyword arguments:
 
-- `nchunks::Int` (default `nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
-- `schedule::Symbol` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. Options are one of
-    - `:dynamic`: generally preferred since it is more flexible and better at load balancing, and won't interfere with other multithreaded functions which may be running on the system.
-    - `:static`: can sometimes be more performant than `:dynamic` when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
-    - `:greedy`: best option for load-balancing slower, uneven computations, but does carry some additional overhead. This schedule only works if the `OutputElementType` argument is provided.
-    - `:interactive`: like `:dynamic` but runs on the high-priority interactive threadpool. This should be used very carefully since tasks on this threadpool should not be allowed to run for a long time without `yield`ing as it can interfere with [heartbeat](https://en.wikipedia.org/wiki/Heartbeat_(computing)) processes running on the interactive threadpool.
+- `scheduler::Scheduler` (default `DynamicScheduler()`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information.
 """
 function tcollect end
 
@@ -281,7 +199,6 @@ include("tools.jl")
 include("schedulers.jl")
 using .Schedulers: Scheduler, DynamicScheduler, StaticScheduler, GreedyScheduler
 include("implementation.jl")
-
 
 export treduce, tmapreduce, treducemap, tmap, tmap!, tforeach, tcollect
 export Scheduler, DynamicScheduler, StaticScheduler, GreedyScheduler

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -4,6 +4,7 @@ import OhMyThreads: treduce, tmapreduce, treducemap, tforeach, tmap, tmap!, tcol
 
 using OhMyThreads: StableTasks, chunks, @spawn, @spawnat
 using OhMyThreads.Tools: nthtid
+using OhMyThreads: Scheduler, DynamicScheduler, StaticScheduler, GreedyScheduler
 using Base: @propagate_inbounds
 using Base.Threads: nthreads, @threads
 
@@ -20,7 +21,7 @@ function tmapreduce(f, op, Arrs...;
     if length(mapreduce_kwargs) > min_kwarg_len
         tmapreduce_kwargs_err(;mapreduce_kwargs...)
     end
-    if schedule === :dynamic 
+    if schedule === :dynamic
         _tmapreduce(f, op, Arrs, outputtype, nchunks, split, :default, mapreduce_kwargs)
     elseif schedule === :interactive
         _tmapreduce(f, op, Arrs, outputtype, nchunks, split, :interactive, mapreduce_kwargs)
@@ -89,7 +90,7 @@ check_all_have_same_indices(Arrs) = let A = first(Arrs), Arrs = Arrs[2:end]
     if !all(B -> eachindex(A) == eachindex(B), Arrs)
         error("The indices of the input arrays must match the indices of the output array.")
     end
-end 
+end
 
 #-------------------------------------------------------------
 

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -11,34 +11,43 @@ using Base.Threads: nthreads, @threads
 using BangBang: BangBang, append!!
 
 function tmapreduce(f, op, Arrs...;
-    scheduler::Scheduler=DynamicScheduler(),
-    outputtype::Type=Any,
-    mapreduce_kwargs...)
-
+        scheduler::Scheduler = DynamicScheduler(),
+        outputtype::Type = Any,
+        mapreduce_kwargs...)
     min_kwarg_len = haskey(mapreduce_kwargs, :init) ? 1 : 0
     if length(mapreduce_kwargs) > min_kwarg_len
-        tmapreduce_kwargs_err(;mapreduce_kwargs...)
+        tmapreduce_kwargs_err(; mapreduce_kwargs...)
     end
     _tmapreduce(f, op, Arrs, outputtype, scheduler, mapreduce_kwargs)
 end
 
-@noinline function tmapreduce_kwargs_err(;init=nothing, kwargs...)
+@noinline function tmapreduce_kwargs_err(; init = nothing, kwargs...)
     error("got unsupported keyword arguments: $((;kwargs...,)) ")
 end
 
 treducemap(op, f, A...; kwargs...) = tmapreduce(f, op, A...; kwargs...)
 
-function _tmapreduce(f, op, Arrs, ::Type{OutputType}, scheduler::DynamicScheduler, mapreduce_kwargs)::OutputType where {OutputType}
+function _tmapreduce(f,
+        op,
+        Arrs,
+        ::Type{OutputType},
+        scheduler::DynamicScheduler,
+        mapreduce_kwargs)::OutputType where {OutputType}
     (; nchunks, split, threadpool) = scheduler
     check_all_have_same_indices(Arrs)
-    tasks = map(chunks(first(Arrs); n=nchunks, split)) do inds
+    tasks = map(chunks(first(Arrs); n = nchunks, split)) do inds
         args = map(A -> view(A, inds), Arrs)
         @spawn threadpool mapreduce(f, op, args...; $mapreduce_kwargs...)
     end
     mapreduce(fetch, op, tasks)
 end
 
-function _tmapreduce(f, op, Arrs, ::Type{OutputType}, scheduler::GreedyScheduler, mapreduce_kwargs)::OutputType where {OutputType}
+function _tmapreduce(f,
+        op,
+        Arrs,
+        ::Type{OutputType},
+        scheduler::GreedyScheduler,
+        mapreduce_kwargs)::OutputType where {OutputType}
     ntasks_desired = scheduler.ntasks
     if Base.IteratorSize(first(Arrs)) isa Base.SizeUnknown
         ntasks = ntasks_desired
@@ -48,8 +57,8 @@ function _tmapreduce(f, op, Arrs, ::Type{OutputType}, scheduler::GreedyScheduler
         ntasks = min(length(first(Arrs)), ntasks_desired)
         ch_len = length(first(Arrs))
     end
-    ch = Channel{Tuple{eltype.(Arrs)...}}(ch_len; spawn=true) do ch
-        for args ∈ zip(Arrs...)
+    ch = Channel{Tuple{eltype.(Arrs)...}}(ch_len; spawn = true) do ch
+        for args in zip(Arrs...)
             put!(ch, args)
         end
     end
@@ -61,7 +70,12 @@ function _tmapreduce(f, op, Arrs, ::Type{OutputType}, scheduler::GreedyScheduler
     mapreduce(fetch, op, tasks; mapreduce_kwargs...)
 end
 
-function _tmapreduce(f, op, Arrs, ::Type{OutputType}, scheduler::StaticScheduler, mapreduce_kwargs) where {OutputType}
+function _tmapreduce(f,
+        op,
+        Arrs,
+        ::Type{OutputType},
+        scheduler::StaticScheduler,
+        mapreduce_kwargs) where {OutputType}
     (; nchunks, split) = scheduler
     check_all_have_same_indices(Arrs)
     n = min(nthreads(), nchunks) # We could implement strategies, like round-robin, in the future
@@ -73,10 +87,11 @@ function _tmapreduce(f, op, Arrs, ::Type{OutputType}, scheduler::StaticScheduler
     mapreduce(fetch, op, tasks)
 end
 
-
-check_all_have_same_indices(Arrs) = let A = first(Arrs), Arrs = Arrs[2:end]
-    if !all(B -> eachindex(A) == eachindex(B), Arrs)
-        error("The indices of the input arrays must match the indices of the output array.")
+function check_all_have_same_indices(Arrs)
+    let A = first(Arrs), Arrs = Arrs[2:end]
+        if !all(B -> eachindex(A) == eachindex(B), Arrs)
+            error("The indices of the input arrays must match the indices of the output array.")
+        end
     end
 end
 
@@ -89,7 +104,7 @@ end
 #-------------------------------------------------------------
 
 function tforeach(f, A...; kwargs...)::Nothing
-    tmapreduce(f, (l, r) -> l, A...; kwargs..., init=nothing, outputtype=Nothing)
+    tmapreduce(f, (l, r) -> l, A...; kwargs..., init = nothing, outputtype = Nothing)
 end
 
 #-------------------------------------------------------------
@@ -99,7 +114,11 @@ function tmap(f, ::Type{T}, A::AbstractArray, _Arrs::AbstractArray...; kwargs...
     tmap!(f, similar(A, T), Arrs...; kwargs...)
 end
 
-function tmap(f, A::AbstractArray, _Arrs::AbstractArray...; scheduler::Scheduler=DynamicScheduler(), kwargs...)
+function tmap(f,
+        A::AbstractArray,
+        _Arrs::AbstractArray...;
+        scheduler::Scheduler = DynamicScheduler(),
+        kwargs...)
     if scheduler isa GreedyScheduler
         error("Greedy scheduler isn't supported with `tmap` unless you provide an `OutputElementType` argument, since the greedy schedule requires a commutative reducing operator.")
     end
@@ -109,7 +128,7 @@ function tmap(f, A::AbstractArray, _Arrs::AbstractArray...; scheduler::Scheduler
     end
     Arrs = (A, _Arrs...)
     check_all_have_same_indices(Arrs)
-    chunk_idcs = collect(chunks(A; n=nchunks))
+    chunk_idcs = collect(chunks(A; n = nchunks))
     v = tmapreduce(append!!, chunk_idcs; scheduler, kwargs...) do inds
         args = map(A -> @view(A[inds]), Arrs)
         map(f, args...)
@@ -117,7 +136,12 @@ function tmap(f, A::AbstractArray, _Arrs::AbstractArray...; scheduler::Scheduler
     reshape(v, size(A)...)
 end
 
-@propagate_inbounds function tmap!(f, out, A::AbstractArray, _Arrs::AbstractArray...; scheduler::Scheduler=DynamicScheduler(), kwargs...)
+@propagate_inbounds function tmap!(f,
+        out,
+        A::AbstractArray,
+        _Arrs::AbstractArray...;
+        scheduler::Scheduler = DynamicScheduler(),
+        kwargs...)
     if hasfield(typeof(scheduler), :split) && scheduler.split != :batch
         error("Only `split == :batch` is supported because the parallel operation isn't commutative. (Scheduler: $scheduler)")
     end

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -20,10 +20,13 @@ they can migrate between threads.
 - `split::Symbol` (default `:batch`):
     * Determines how the collection is divided into chunks. By default, each chunk consists of contiguous elements.
     * See [ChunkSplitters.jl](https://github.com/JuliaFolds2/ChunkSplitters.jl) for more details and available options.
+- `threadpool::Symbol` (default `:default`):
+    * Possible options are `:default` and `:interactive`.
 """
 Base.@kwdef struct DynamicScheduler <: Scheduler
-    nchunks::Int  = 2 * nthreads() # a multiple of nthreads to enable load balancing
+    nchunks::Int = 2 * nthreads() # a multiple of nthreads to enable load balancing
     split::Symbol = :batch
+    threadpool::Symbol = :default
 end
 
 """
@@ -43,7 +46,7 @@ they are guaranteed to stay on the assigned threads (**no task migration**).
     * See [ChunkSplitters.jl](https://github.com/JuliaFolds2/ChunkSplitters.jl) for more details and available options.
 """
 Base.@kwdef struct StaticScheduler <: Scheduler
-    nchunks::Int  = nthreads()
+    nchunks::Int = nthreads()
     split::Symbol = :batch
 end
 
@@ -60,7 +63,7 @@ some additional overhead.
     * Setting `nchunks < nthreads()` is an effective way to use only a subset of the available threads.
 """
 Base.@kwdef struct GreedyScheduler <: Scheduler
-    ntasks::Int  = nthreads()
+    ntasks::Int = nthreads()
 end
 
 end # module

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -22,7 +22,7 @@ with other multithreaded code.
 
 ## Keyword arguments:
 
-- `nchunks::Int` (default `2 * nthreads()`):
+- `nchunks::Int` (default `2 * nthreads(threadpool)`):
     * Determines the number of chunks (and thus also the number of parallel tasks).
     * Increasing `nchunks` can help with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead. For `nchunks <= nthreads()` there are not enough chunks for any load balancing.
     * Setting `nchunks < nthreads()` is an effective way to use only a subset of the available threads.
@@ -34,14 +34,14 @@ with other multithreaded code.
     * The high-priority pool `:interactive` should be used very carefully since tasks on this threadpool should not be allowed to run for a long time without `yield`ing as it can interfere with [heartbeat](https://en.wikipedia.org/wiki/Heartbeat_(computing)) processes.
 """
 Base.@kwdef struct DynamicScheduler <: Scheduler
-    nchunks::Int = 2 * nthreads() # a multiple of nthreads to enable load balancing
-    split::Symbol = :batch
     threadpool::Symbol = :default
+    nchunks::Int = 2 * nthreads(threadpool) # a multiple of nthreads to enable load balancing
+    split::Symbol = :batch
 
-    function DynamicScheduler(nchunks::Int, split::Symbol, threadpool::Symbol)
-        nchunks > 0 || throw(ArgumentError("nchunks must be a positive integer"))
+    function DynamicScheduler(threadpool::Symbol, nchunks::Int, split::Symbol)
         threadpool in (:default, :interactive) ||
             throw(ArgumentError("threadpool must be either :default or :interactive"))
+        nchunks > 0 || throw(ArgumentError("nchunks must be a positive integer"))
         new(nchunks, split, threadpool)
     end
 end

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -1,0 +1,66 @@
+module Schedulers
+
+using Base.Threads: nthreads
+
+"Supertype for all schedulers"
+abstract type Scheduler end
+
+"""
+The default dynamic scheduler. Divides the given collection into chunks and
+then spawns a task per chunk to perform the requested operation in parallel.
+The tasks are assigned to threads by Julia's dynamic scheduler and are non-sticky, that is,
+they can migrate between threads.
+
+## Keyword arguments:
+
+- `nchunks::Int` (default `2 * nthreads()`):
+    * Determines the number of chunks (and thus also the number of parallel tasks).
+    * Increasing `nchunks` can help with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead. For `nchunks <= nthreads()` there are not enough chunks for any load balancing.
+    * Setting `nchunks < nthreads()` is an effective way to use only a subset of the available threads.
+- `split::Symbol` (default `:batch`):
+    * Determines how the collection is divided into chunks. By default, each chunk consists of contiguous elements.
+    * See [ChunkSplitters.jl](https://github.com/JuliaFolds2/ChunkSplitters.jl) for more details and available options.
+"""
+Base.@kwdef struct DynamicScheduler <: Scheduler
+    nchunks::Int  = 2 * nthreads() # a multiple of nthreads to enable load balancing
+    split::Symbol = :batch
+end
+
+"""
+A static low-overhead scheduler. Divides the given collection into chunks and
+then spawns a task per chunk to perform the requested operation in parallel.
+The tasks are statically assigned to threads up front and are made *sticky*, that is,
+they are guaranteed to stay on the assigned threads (**no task migration**).
+
+## Keyword arguments:
+
+- `nchunks::Int` (default `nthreads()`):
+    * Determines the number of chunks (and thus also the number of parallel tasks).
+    * Setting `nchunks < nthreads()` is an effective way to use only a subset of the available threads.
+    * Currently, `nchunks > nthreads()` **isn't officialy supported** but, for now, will fall back to `nchunks = nthreads()`.
+- `split::Symbol` (default `:batch`):
+    * Determines how the collection is divided into chunks. By default, each chunk consists of contiguous elements.
+    * See [ChunkSplitters.jl](https://github.com/JuliaFolds2/ChunkSplitters.jl) for more details and available options.
+"""
+Base.@kwdef struct StaticScheduler <: Scheduler
+    nchunks::Int  = nthreads()
+    split::Symbol = :batch
+end
+
+"""
+A greedy dynamic scheduler. The elements of the collection are first put into a `Channel`
+and then dynamic, non-sticky tasks are spawned to process the elements of the channel in
+parallel. Can be good choice for load-balancing slower, uneven computations, but does carry
+some additional overhead.
+
+## Keyword arguments:
+
+- `ntasks::Int` (default `nthreads()`):
+    * Determines the number of parallel tasks to be spawned.
+    * Setting `nchunks < nthreads()` is an effective way to use only a subset of the available threads.
+"""
+Base.@kwdef struct GreedyScheduler <: Scheduler
+    ntasks::Int  = nthreads()
+end
+
+end # module

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -42,7 +42,7 @@ Base.@kwdef struct DynamicScheduler <: Scheduler
         threadpool in (:default, :interactive) ||
             throw(ArgumentError("threadpool must be either :default or :interactive"))
         nchunks > 0 || throw(ArgumentError("nchunks must be a positive integer"))
-        new(nchunks, split, threadpool)
+        new(threadpool, nchunks, split)
     end
 end
 

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -27,6 +27,13 @@ Base.@kwdef struct DynamicScheduler <: Scheduler
     nchunks::Int = 2 * nthreads() # a multiple of nthreads to enable load balancing
     split::Symbol = :batch
     threadpool::Symbol = :default
+
+    function DynamicScheduler(nchunks::Int, split::Symbol, threadpool::Symbol)
+        nchunks > 0 || throw(ArgumentError("nchunks must be a positive integer"))
+        threadpool in (:default, :interactive) ||
+            throw(ArgumentError("threadpool must be either :default or :interactive"))
+        new(nchunks, split, threadpool)
+    end
 end
 
 """
@@ -48,6 +55,11 @@ they are guaranteed to stay on the assigned threads (**no task migration**).
 Base.@kwdef struct StaticScheduler <: Scheduler
     nchunks::Int = nthreads()
     split::Symbol = :batch
+
+    function StaticScheduler(nchunks::Int, split::Symbol)
+        nchunks > 0 || throw(ArgumentError("nchunks must be a positive integer"))
+        new(nchunks, split)
+    end
 end
 
 """
@@ -64,6 +76,11 @@ some additional overhead.
 """
 Base.@kwdef struct GreedyScheduler <: Scheduler
     ntasks::Int = nthreads()
+
+    function GreedyScheduler(ntasks::Int)
+        ntasks > 0 || throw(ArgumentError("ntasks must be a positive integer"))
+        new(ntasks)
+    end
 end
 
 end # module


### PR DESCRIPTION
This PR introduces structs for different schedulers. This enables us to have different options (fields) and default values for different schedulers (#22).

**Notes:**
* The static and dynamic schedulers have `nchunks` but the greedy scheduler has `ntasks`, because it doesn't do any chunking.
* We default to `nthreads()` tasks for static and greedy but `2*nthreads()` tasks for dynamic to have a bit of load balancing by default. (unclear if this is the best choice, see questions below)

**Questions:**
* Should the default for `DynamicScheduler` be `nchunks = 2*nthreads()` or `nchunks = nthreads()`, i.e. load balancing or not?
* Maybe we should choose the latter and have a separate `LoadBalancingScheduler` as an alias for `DynamicScheduler(nchunks=2*nthreads)`?
* Should we export all scheduler structs? (I currently do)

Closes #22 