### PR TITLE
Bump StableTasks.jl dep to forward `@fetch` and `@fetchfrom` macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ OhMyThreads.jl Changelog
 Version 0.4.3
 -------------
 
-- ![Feature][badge-feature] We now forward (but don't export) the macros `@fetch` and `@fetchfrom` from StableTasks.jl (v0.1.5), which are analogous to same-named macros in Distributed.jl.
+- ![Feature][badge-feature] We now forward (but don't export) the macros `@fetch` and `@fetchfrom` from StableTasks.jl (v0.1.5), which are analogous to the same-named macros in Distributed.jl.
 
 Version 0.4.2
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 OhMyThreads.jl Changelog
 =========================
 
+Version 0.4.3
+-------------
+
+- ![Feature][badge-feature] We now forward (but don't export) the macros `@fetch` and `@fetchfrom` from StableTasks.jl (v0.1.5), which are analogous to same-named macros in Distributed.jl.
+
 Version 0.4.2
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ OhMyThreads.jl Changelog
 Version 0.4.3
 -------------
 
-- ![Feature][badge-feature] We now forward (but don't export) the macros `@fetch` and `@fetchfrom` from StableTasks.jl (v0.1.5), which are analogous to the same-named macros in Distributed.jl.
+- ![Feature][badge-feature] Forward (but don't export) the macros `@fetch` and `@fetchfrom` from StableTasks.jl (v0.1.5), which are analogous to the same-named macros in Distributed.jl.
 
 Version 0.4.2
 -------------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OhMyThreads"
 uuid = "67456a42-1dca-4109-a031-0a68de7e3ad5"
 authors = ["Mason Protter <mason.protter@icloud.com>"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
@@ -12,7 +12,7 @@ TaskLocalValues = "ed4db957-447d-4319-bfb6-7fa9ae7ecf34"
 [compat]
 BangBang = "0.4"
 ChunkSplitters = "2.1"
-StableTasks = "0.1.4"
+StableTasks = "0.1.5"
 TaskLocalValues = "0.1"
 julia = "1.6"
 

--- a/docs/src/refs/api.md
+++ b/docs/src/refs/api.md
@@ -36,5 +36,7 @@ GreedyScheduler
 |------------------------|---------------------------------------------------------------------|
 | `OhMyThreads.@spawn`   | see [StableTasks.jl](https://github.com/JuliaFolds2/StableTasks.jl) |
 | `OhMyThreads.@spawnat` | see [StableTasks.jl](https://github.com/JuliaFolds2/StableTasks.jl) |
+| `OhMyThreads.@fetch`   | see [StableTasks.jl](https://github.com/JuliaFolds2/StableTasks.jl) |
+| `OhMyThreads.@fetchfrom` | see [StableTasks.jl](https://github.com/JuliaFolds2/StableTasks.jl) |
 | `OhMyThreads.chunks`   | see [ChunkSplitters.jl](https://juliafolds2.github.io/ChunkSplitters.jl/dev/references/#ChunkSplitters.chunks) |
 | `OhMyThreads.TaskLocalValue`   | see [TaskLocalValues.jl](https://github.com/vchuravy/TaskLocalValues.jl) |

--- a/src/OhMyThreads.jl
+++ b/src/OhMyThreads.jl
@@ -1,6 +1,6 @@
 module OhMyThreads
 
-using StableTasks: StableTasks, @spawn, @spawnat
+using StableTasks: StableTasks, @spawn, @spawnat, @fetch, @fetchfrom
 using ChunkSplitters: ChunkSplitters, chunks
 using TaskLocalValues: TaskLocalValues, TaskLocalValue
 


### PR DESCRIPTION
Only merge after StableTasks.jl v0.1.5 is registered (https://github.com/JuliaRegistries/General/pull/101308)