### PR TITLE
Remove stale imports etc

### DIFF
--- a/src/OhMyThreads.jl
+++ b/src/OhMyThreads.jl
@@ -1,8 +1,8 @@
 module OhMyThreads
 
-using StableTasks: StableTasks, @spawn, @spawnat, @fetch, @fetchfrom
-using ChunkSplitters: ChunkSplitters, chunks
-using TaskLocalValues: TaskLocalValues, TaskLocalValue
+using StableTasks: @spawn, @spawnat, @fetch, @fetchfrom
+using ChunkSplitters: chunks
+using TaskLocalValues: TaskLocalValue
 
 """
     tmapreduce(f, op, A::AbstractArray...;
@@ -198,7 +198,7 @@ function tcollect end
 include("tools.jl")
 include("schedulers.jl")
 using .Schedulers: Scheduler,
-    DynamicScheduler, StaticScheduler, GreedyScheduler, SpawnAllScheduler, chunking_enabled
+    DynamicScheduler, StaticScheduler, GreedyScheduler, SpawnAllScheduler
 include("implementation.jl")
 
 export treduce, tmapreduce, treducemap, tmap, tmap!, tforeach, tcollect

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -2,14 +2,14 @@ module Implementation
 
 import OhMyThreads: treduce, tmapreduce, treducemap, tforeach, tmap, tmap!, tcollect
 
-using OhMyThreads: StableTasks, chunks, @spawn, @spawnat
+using OhMyThreads: chunks, @spawn, @spawnat
 using OhMyThreads.Tools: nthtid
-using OhMyThreads: Scheduler,
-    chunking_enabled, DynamicScheduler, StaticScheduler, GreedyScheduler
+using OhMyThreads: Scheduler, DynamicScheduler, StaticScheduler, GreedyScheduler
+using OhMyThreads.Schedulers: chunking_enabled
 using Base: @propagate_inbounds
 using Base.Threads: nthreads, @threads
 
-using BangBang: BangBang, append!!
+using BangBang: append!!
 
 using ChunkSplitters: ChunkSplitters
 

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -50,8 +50,6 @@ Base.@kwdef struct DynamicScheduler{C} <: Scheduler
     end
 end
 
-chunking_enabled(::DynamicScheduler{C}) where {C} = C
-
 """
 A static low-overhead scheduler. Divides the given collection into chunks and
 then spawns a task per chunk to perform the requested operation in parallel.
@@ -84,8 +82,6 @@ Base.@kwdef struct StaticScheduler{C} <: Scheduler
     end
 end
 
-chunking_enabled(::StaticScheduler{C}) where {C} = C
-
 """
 A greedy dynamic scheduler. The elements of the collection are first put into a `Channel`
 and then dynamic, non-sticky tasks are spawned to process channel content in parallel.
@@ -112,10 +108,13 @@ Base.@kwdef struct GreedyScheduler <: Scheduler
     end
 end
 
-chunking_enabled(::GreedyScheduler) = false
-
 @deprecate SpawnAllScheduler(args...; kwargs...) DynamicScheduler(args...;
     nchunks = 0,
     kwargs...)
+
+chunking_enabled(s::Scheduler) = chunking_enabled(typeof(s))
+chunking_enabled(::Type{DynamicScheduler{C}}) where {C} = C
+chunking_enabled(::Type{StaticScheduler{C}}) where {C} = C
+chunking_enabled(::Type{GreedyScheduler}) = false
 
 end # module


### PR DESCRIPTION
I applied ExplicitImports.jl to our package and remove some stale imports in here. 

(Also, I add type-based variants of `Schedulers.chunking_enabled` but that should be a minor thing.)