### PR TITLE
Add `WithTaskLocals` to make the handling of task local values more efficient.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,11 @@
 OhMyThreads.jl Changelog
 =========================
 
-Version 0.5.1
+Version 0.5.0
 -------------
 
 - ![feature][badge-feature] Added `OhMyThreads.WithTaskLocals` that represents a closure over `TaskLocalValues`, but can have those values materialized as an optimization (using `OhMyThreads.promise_task_local`)
 - ![Enhancement][badge-enhancement] Made `@tasks` use `OhMyThreads.WithTaskLocals` automatically as an optimization.
-
-Version 0.5.0
--------------
-
 - ![Feature][badge-feature] `@set init = ...` may now be used to specify an initial value for a reduction (only has an effect in conjuction with `@set reducer=...` and triggers a warning otherwise).
 - ![BREAKING][badge-breaking] Within a `@tasks` block, task-local values must from now on be defined via `@local` instead of `@init` (renamed).
 - ![BREAKING][badge-breaking] The (already deprecated) `SpawnAllScheduler` has been dropped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 OhMyThreads.jl Changelog
 =========================
 
+Version 0.4.7
+-------------
+
+- ![feature][badge-feature] Added `OhMyThreads.WithTaskLocals` that represents a closure over `TaskLocalValues`, but can have those values materialized as an optimization (using `OhMyThreads.promise_task_local`)
+- ![Enhancement][badge-enhancement] Made `@tasks` use `OhMyThreads.WithTaskLocals` automatically as an optimization.
+
 Version 0.4.6
 -------------
 

--- a/docs/src/refs/api.md
+++ b/docs/src/refs/api.md
@@ -44,3 +44,9 @@ GreedyScheduler
 | `OhMyThreads.@fetchfrom` | see [StableTasks.jl](https://github.com/JuliaFolds2/StableTasks.jl) |
 | `OhMyThreads.chunks`   | see [ChunkSplitters.jl](https://juliafolds2.github.io/ChunkSplitters.jl/dev/references/#ChunkSplitters.chunks) |
 | `OhMyThreads.TaskLocalValue`   | see [TaskLocalValues.jl](https://github.com/vchuravy/TaskLocalValues.jl) |
+
+
+```@docs
+OhMyThreads.WithTaskLocals
+OhMyThreads.promise_task_local
+```

--- a/src/OhMyThreads.jl
+++ b/src/OhMyThreads.jl
@@ -10,7 +10,7 @@ const chunks = ChunkSplitters.chunks
 
 using TaskLocalValues: TaskLocalValues
 const TaskLocalValue = TaskLocalValues.TaskLocalValue
-
+include("types.jl")
 include("functions.jl")
 include("macros.jl")
 

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -2,7 +2,7 @@ module Implementation
 
 import OhMyThreads: treduce, tmapreduce, treducemap, tforeach, tmap, tmap!, tcollect
 
-using OhMyThreads: chunks, @spawn, @spawnat, WithTaskLocalValues, promise_task_local
+using OhMyThreads: chunks, @spawn, @spawnat, WithTaskLocals, promise_task_local
 using OhMyThreads.Tools: nthtid
 using OhMyThreads: Scheduler, DynamicScheduler, StaticScheduler, GreedyScheduler
 using OhMyThreads.Schedulers: chunking_enabled
@@ -205,14 +205,14 @@ end
 """
    maybe_rewrap(g, f)
 
-takes a closure `g(f)` and if `f` is a `WithTaskLocalValues`, we're going
+takes a closure `g(f)` and if `f` is a `WithTaskLocals`, we're going
 to unwrap `f` and delegate its `TaskLocalValues` to `g`.
 
 This should always be equivalent to just calling `g(f)`.
 """
-function maybe_rewrap(g::G, f::WithTaskLocalValues{F}) where {G, F}
+function maybe_rewrap(g::G, f::WithTaskLocals{F}) where {G, F}
     (;inner_func, tasklocalvalues) = f
-    WithTaskLocalValues(f.tasklocalvalues) do vals
+    WithTaskLocals(f.tasklocals) do vals
         f = inner_func(vals)
         g(f)
     end

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -211,7 +211,7 @@ to unwrap `f` and delegate its `TaskLocalValues` to `g`.
 This should always be equivalent to just calling `g(f)`.
 """
 function maybe_rewrap(g::G, f::WithTaskLocals{F}) where {G, F}
-    (;inner_func, tasklocalvalues) = f
+    (;inner_func, tasklocals) = f
     WithTaskLocals(f.tasklocals) do vals
         f = inner_func(vals)
         g(f)

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -212,10 +212,7 @@ This should always be equivalent to just calling `g(f)`.
 """
 function maybe_rewrap(g::G, f::WithTaskLocals{F}) where {G, F}
     (;inner_func, tasklocals) = f
-    WithTaskLocals(f.tasklocals) do vals
-        f = inner_func(vals)
-        g(f)
-    end
+    WithTaskLocals(vals -> g(inner_func(vals)), tasklocals)
 end
 
 #------------------------------------------------------------
@@ -313,7 +310,7 @@ function _tmap(scheduler::Scheduler,
     idcs = collect(chunks(A; n = scheduler.nchunks))
     reduction_f = append!!
     mapping_f = maybe_rewrap(f) do f
-        function mapping_function(inds)
+        (inds) -> begin
             args = map(A -> @view(A[inds]), Arrs)
             map(f, args...)
         end

--- a/src/macro_impl.jl
+++ b/src/macro_impl.jl
@@ -32,7 +32,7 @@ function tasks_macro(forex)
           end)
 
     else
-        :(local mapping_function = WithTaskLocalValues($(tls_names...),) do $(inits_names...)
+        :(local mapping_function = WithTaskLocalValues(($(tls_names...),)) do ($(inits_names...),)
               function mapping_function_local($itvar,)
                   $(forbody)
               end

--- a/src/macro_impl.jl
+++ b/src/macro_impl.jl
@@ -18,7 +18,7 @@ function tasks_macro(forex)
     settings = Settings()
 
     inits_before, inits_names = _maybe_handle_init_block!(forbody.args)
-    tls_names = map(x -> x.args[1], inits_before)
+    tls_names = isnothing(inits_before) ? [] : map(x -> x.args[1], inits_before)
     
     _maybe_handle_set_block!(settings, forbody.args)
 

--- a/src/macro_impl.jl
+++ b/src/macro_impl.jl
@@ -17,7 +17,7 @@ function tasks_macro(forex)
 
     settings = Settings()
 
-    locals_before, local_inner = _maybe_handle_atlocal_block!(forbody.args)
+    locals_before, locals_names = _maybe_handle_atlocal_block!(forbody.args)
     tls_names = isnothing(locals_before) ? [] : map(x -> x.args[1], locals_before)
     _maybe_handle_atset_block!(settings, forbody.args)
 
@@ -31,7 +31,7 @@ function tasks_macro(forex)
           end)
 
     else
-        :(local mapping_function = WithTaskLocals(($(tls_names...),)) do ($(inits_names...),)
+        :(local mapping_function = WithTaskLocals(($(tls_names...),)) do ($(locals_names...),)
               function mapping_function_local($itvar,)
                   $(forbody)
               end

--- a/src/macro_impl.jl
+++ b/src/macro_impl.jl
@@ -111,13 +111,13 @@ function _unfold_atlocal_block(ex)
     locals_before = Expr[]
     locals_names = Expr[]
     if ex.head == :(=)
-        localb, localn = _init_assign_to_exprs(ex)
+        localb, localn = _atlocal_assign_to_exprs(ex)
         push!(locals_before, initb)
         push!(locals_names, localn)
     elseif ex.head == :block
         tlsexprs = filter(x -> x isa Expr, ex.args) # skip LineNumberNode
         for x in tlsexprs
-            localb, localn = _init_assign_to_exprs(x)
+            localb, localn = _atlocal_assign_to_exprs(x)
             push!(locals_before, localb)
             push!(locals_names,  localn)
         end

--- a/src/macro_impl.jl
+++ b/src/macro_impl.jl
@@ -112,7 +112,7 @@ function _unfold_atlocal_block(ex)
     locals_names = Expr[]
     if ex.head == :(=)
         localb, localn = _atlocal_assign_to_exprs(ex)
-        push!(locals_before, initb)
+        push!(locals_before, localb)
         push!(locals_names, localn)
     elseif ex.head == :block
         tlsexprs = filter(x -> x isa Expr, ex.args) # skip LineNumberNode

--- a/src/macro_impl.jl
+++ b/src/macro_impl.jl
@@ -124,7 +124,7 @@ function _unfold_atlocal_block(ex)
     else
         throw(ErrorException("Wrong usage of @local. You must either provide a typed assignment or multiple typed assignments in a `begin ... end` block."))
     end
-    return locals_before, local_inner
+    return locals_before, locals_names
 end
 
 function _atlocal_assign_to_exprs(ex)

--- a/src/macro_impl.jl
+++ b/src/macro_impl.jl
@@ -32,7 +32,7 @@ function tasks_macro(forex)
           end)
 
     else
-        :(local mapping_function = WithTaskLocalValues(($(tls_names...),)) do ($(inits_names...),)
+        :(local mapping_function = WithTaskLocals(($(tls_names...),)) do ($(inits_names...),)
               function mapping_function_local($itvar,)
                   $(forbody)
               end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -77,7 +77,7 @@ end
 
 Can be used inside a `@tasks for ... end` block to specify
 [task-local values](@ref TLS) (TLV) via explicitly typed assignments.
-These values will be allocated once per task
+These values will be allocated and de-referenced once per task
 (rather than once per iteration) and can be re-used between different task-local iterations.
 
 There can only be a single `@init` block in a `@tasks for ... end` block. To specify

--- a/src/types.jl
+++ b/src/types.jl
@@ -56,6 +56,7 @@ let x = TLV{Int}(() -> 1), y = TLV{Int}(() -> 2)
         z -> (x + y)/z
     end
 end
+```
 which doesn't have the overhead of accessing the `task_local_storage` each time the closure is called.
 This of course will lose the safety advantages of `TaskLocalValue`, so you should never do
 `f_local = promise_task_local(f)` and then pass `f_local` to some unknown function, because if that

--- a/src/types.jl
+++ b/src/types.jl
@@ -2,7 +2,7 @@
     struct WithTaskLocals{F, TLVs <: Tuple{Vararg{TaskLocalValue}}} <: Function
 
 This callable function-like object is meant to represent a function which closes over some
-[`TaskLocalValues`](@ref). This is, if you do
+[`TaskLocalValues`](https://github.com/vchuravy/TaskLocalValues.jl). This is, if you do
 
 ```
 TLV{T} = TaskLocalValue{T}

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,0 +1,67 @@
+"""
+    struct WithTaskLocalValues{F, TLVs <: Tuple{Vararg{TaskLocalValue}}} <: Function
+
+This callable function-like object is meant to represent a function which closes over some
+[`TaskLocalValues`](@ref). This is, if you do
+
+```
+TLV{T} = TaskLocalValue{T}
+f = WithTaskLocalValues(TLV{Int}(() -> 1), TLV{Int}(() -> 2)) do x, y
+    z -> (x + y)/z
+end
+```
+then that is equivalent to
+```
+g = let x = TLV{Int}(() -> 1), y = TLV{Int}(() -> 2)
+    z -> let x = x[], y=y[]
+        (x + y)/z
+    end
+end
+```
+however, the main difference is that you can call [`promise_task_local`](@ref) on a
+`WithTaskLocalValues` closure in order to turn it into something equivalent to
+```
+let x=x[], y=y[]
+    z -> (x + y)/z
+end
+```
+which doesn't have the overhead of accessing the `tasklocal_storage` each time
+the function is called.
+"""
+struct WithTaskLocalValues{F, TLVs <: Tuple{Vararg{TaskLocalValue}}} <: Function
+    inner_func::F
+    tasklocalvalues::TLVs
+    function WithTaskLocalValues(f::F, args...) where {F}
+        new{F, typeof(args)}(f, args)
+    end
+end
+
+"""
+    promise_task_local(f) = f
+    promise_task_local(f::WithTaskLocalValues) = f.inner_func(map(x -> x[], f.tasklocalvalues)...)
+
+Take a `WithTaskLocalValues` closure, grab the `TaskLocalValue`s, and passs them to the closure. That is,
+it turns a `WithTaskLocalValues` closure from the equivalent of
+```
+TLV{T} = TaskLocalValue{T}
+let x = TLV{Int}(() -> 1), y = TLV{Int}(() -> 2)
+    z -> let x = x[], y=y[]
+        (x + y)/z
+    end
+end
+```
+into the equivalent of
+```
+let x = TLV{Int}(() -> 1), y = TLV{Int}(() -> 2)
+    let x = x[], y = y[]
+        z -> (x + y)/z
+    end
+end
+```
+"""
+promise_task_local(f::WithTaskLocalValues) = f.inner_func(map(x -> x[], f.tasklocalvalues)...)
+promise_task_local(f::Any) = f
+
+function (f::WithTaskLocalValues{F, TLVs})(args...; kwargs...) where {F, TLVs}
+    promise_task_local(f)(args...; kwargs...)
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -25,8 +25,10 @@ let x=x[], y=y[]
     z -> (x + y)/z
 end
 ```
-which doesn't have the overhead of accessing the `tasklocal_storage` each time
-the function is called.
+which doesn't have the overhead of accessing the `task_local_storage` each time the closure is called.
+This of course will lose the safety advantages of `TaskLocalValue`, so you should never do
+`f_local = promise_task_local(f)` and then pass `f_local` to some unknown function, because if that
+unknown function calls `f_local` on a new task, you'll hit a race condition. 
 """
 struct WithTaskLocalValues{F, TLVs <: Tuple{Vararg{TaskLocalValue}}} <: Function
     inner_func::F
@@ -57,6 +59,10 @@ let x = TLV{Int}(() -> 1), y = TLV{Int}(() -> 2)
         z -> (x + y)/z
     end
 end
+which doesn't have the overhead of accessing the `task_local_storage` each time the closure is called.
+This of course will lose the safety advantages of `TaskLocalValue`, so you should never do
+`f_local = promise_task_local(f)` and then pass `f_local` to some unknown function, because if that
+unknown function calls `f_local` on a new task, you'll hit a race condition. 
 ```
 """
 function promise_task_local(f::WithTaskLocalValues{F}) where {F}


### PR DESCRIPTION
## What?

This gives a way to make it  so that you don't have to access the `TaskLocalValue` every look iteration. Rather, you only access the `TaskLocalValue` after we `@spawn` a task, i.e. basically it should match the way that you would manually use `task_local_storage`.

For things where each iteration takes a long time, this is pretty insignificant, since accessing task local storage only takes around 10ns, but for fast functions this can be really important. 

E.g. suppose we have a thread local accumulator we use in a sum:
```julia
julia> using OhMyThreads

julia> function sum_accumulator_macro(ns)
           @tasks for n ∈ ns
               @set reducer = (+)
               @init acc::(Base.RefValue{Int}) = Ref{Int}()
               acc[] = 0
               for i ∈ 1:n
                   acc[] += i
               end
               acc[]
           end
       end;

julia> function sum_accumulator(ns)
           acc = OhMyThreads.TaskLocalValue{Base.RefValue{Int}}(() -> Ref{Int}())
           tmapreduce(+, ns) do n
               acc[][] = 0
               for i ∈ 1:n
                   acc[][] += i
               end
               acc[][]
           end
       end;

julia> let ns = rand(1:10, 10000)
           r1 = @btime sum_accumulator_macro($ns)
           r2 = @btime sum_accumulator($ns)
           r1 ≈ r2
       end
  5.907 μs (120 allocations: 11.46 KiB)
  97.294 μs (120 allocations: 11.45 KiB)
true
```
Now, one can fairly say "Well, you shouldn't have re-accessed `acc` so many times in the body of `sum_accumulator`!" Which is true, but even then, `sum_accumulator_macro` is significantly faster
```julia
julia> function sum_accumulator_better(ns)
           acc = OhMyThreads.TaskLocalValue{Base.RefValue{Int}}(() -> Ref{Int}())
           tmapreduce(+, ns) do n
               r =  acc[]
               r[] = 0
               for i ∈ 1:n
                   r[] += i
               end
               r[]
           end
       end;

julia> let ns = rand(1:10, 10000)
           r1 = @btime sum_accumulator_macro($ns)
           r2 = @btime sum_accumulator_better($ns)
           r1 ≈ r2
       end
  5.951 μs (120 allocations: 11.46 KiB)
  21.080 μs (120 allocations: 11.45 KiB)
true
```
And here's what these would look like if we do a `map` instead:
```julia
julia> function map_accumulator_macro(ns)
           @tasks for n ∈ ns
               @set collect = true
               @init acc::(Base.RefValue{Int}) = Ref{Int}()
               acc[] = 0
               for i ∈ 1:n
                   acc[] += i
               end
               acc[]
           end
       end;

julia> function map_accumulator(ns)
           acc = OhMyThreads.TaskLocalValue{Base.RefValue{Int}}(() -> Ref{Int}())
           tmap(ns) do n
               acc[][] = 0
               for i ∈ 1:n
                   acc[][] += i
               end
               acc[][]
           end
       end;

julia> function map_accumulator_better(ns)
           acc = OhMyThreads.TaskLocalValue{Base.RefValue{Int}}(() -> Ref{Int}())
           tmap(ns) do n
               r =  acc[]
               r[] = 0
               for i ∈ 1:n
                   r[] += i
               end
               r[]
           end
       end;

julia> let ns = rand(1:10, 10000)
           r1 = @btime map_accumulator_macro($ns)
           r2 = @btime map_accumulator($ns)
           r3 = @btime map_accumulator_better($ns)
           r1 ≈ r2 ≈ r3
       end
  18.064 μs (206 allocations: 245.02 KiB)
  110.309 μs (138 allocations: 242.41 KiB)
  33.824 μs (138 allocations: 242.41 KiB)
true
```

## What about a less cherry picked example?

This gain becomes more and more mild, the longer the function call takes. E.g. if I re-run the benchmarks in https://juliafolds2.github.io/OhMyThreads.jl/v0.4/literate/tls/tls/#Benchmark, I find 
```julia
julia> let As = [rand(2056, 32) for _ in 1:192],
           Bs = [rand(32, 2056) for _ in 1:192]
           r1 = @btime matmulsums_manual($As, $Bs)    seconds=10
           r2 = @btime matmulsums_tlv($As, $Bs)       seconds=10
           r3 = @btime matmulsums_tlv_macro($As, $Bs) seconds=10
           r1 ≈ r2 ≈ r3
       end
  1.061 s (124 allocations: 387.03 MiB)
  1.082 s (148 allocations: 387.02 MiB)
  1.058 s (207 allocations: 387.03 MiB)
true
```
so a very small difference, though it puts things more in line with the manual case, as expected, though what I find unexpected is that there's more allocations in this case, I'm not sure what exactly that's about, but I think it has to do with the `map` rewarpping step I had to do. 

Observe that turning these into a reduction, we get:
```julia
julia> function sum_matmulsums_tlv(As, Bs; kwargs...)
           N = size(first(As), 1)
           tlv = TaskLocalValue{Matrix{Float64}}(() -> Matrix{Float64}(undef, N, N))
           tmapreduce(+, As, Bs; kwargs...) do A, B
               C = tlv[]
               mul!(C, A, B)
               sum(C)
           end
       end;

julia> function sum_matmulsums_tlv_macro(As, Bs; kwargs...)
           N = size(first(As), 1)
           @tasks for i in eachindex(As,Bs)
               @set reducer=(+)
               @init C::Matrix{Float64} = Matrix{Float64}(undef, N, N)
               mul!(C, As[i], Bs[i])
               sum(C)
           end
       end;

julia> let As = [rand(2056, 32) for _ in 1:192],
           Bs = [rand(32, 2056) for _ in 1:192]
           r2 = @btime sum_matmulsums_tlv($As, $Bs)       seconds=10
           r3 = @btime sum_matmulsums_tlv_macro($As, $Bs) seconds=10
           r2 ≈ r3
       end
  1.062 s (293 allocations: 387.03 MiB)
  1.056 s (134 allocations: 387.02 MiB)
true
```
which has fewer allocations.

## How does this work?

The key here is a new closure type called `WithTaskLocals` (bikeshedding welcome). Essentially, if you write
```julia
TLV{T} = TaskLocalValue{T}
f = WithTaskLocals(TLV{Int}(() -> 1), TLV{Int}(() -> 2)) do x, y
    z -> (x + y)/z
end
```
then that creates a closure object capturing the `TaskLocalValues` which is equivalent to
```julia
g = let x = TLV{Int}(() -> 1), y = TLV{Int}(() -> 2)
    z -> let x = x[], y=y[]
        (x + y)/z
    end
end
```
however, the main difference is that you can call `promise_task_local` on a
`WithTaskLocals` closure in order to turn it into something equivalent to
```julia
let x=x[], y=y[]
    z -> (x + y)/z
end
```
which doesn't have the overhead of accessing the `task_local_storage` each time the closure is called. This of course will lose the safety advantages of `TaskLocalValue`, so you should never call `f_local = promise_task_local(f)` and then pass `f_local` to some unknown function, because if that unknown function calls `f_local` on a new thread, you'll hit a race condition. 

However, we can take advantage of the structure of `mapreduce` calls to build up `WithTaskLocals` objects from the `@tasks` macro and then pass them to `tmapreduce` and `tmap` and then basically do `@spawn promise_task_local(f)(args...)` because we know at that point that `f` is actually being called so it's safe to make the promise.

## Can we get these performance advantages without using the `@tasks` macro?

You betcha, but it's kinda ugly:
```julia
julia> function sum_accumulator_more_better(ns)
           acc = OhMyThreads.TaskLocalValue{Base.RefValue{Int}}(() -> Ref{Int}())
           f = OhMyThreads.WithTaskLocals((acc,)) do (acc,)
               function f(n)
                   acc[] = 0
                   for i ∈ 1:n
                       acc[] += i
                   end
                   acc[]
               end
           end
           tmapreduce(f, +, ns)
       end;

julia> let ns = rand(1:10, 10000)
           r1 = @btime sum_accumulator_macro($ns)
           r2 = @btime sum_accumulator($ns)
           r3 = @btime sum_accumulator_better($ns)
           r4 = @btime sum_accumulator_more_better($ns)
           r1 ≈ r2 ≈ r3 ≈ r4
       end
  4.996 μs (119 allocations: 11.40 KiB)
  98.105 μs (119 allocations: 11.38 KiB)
  26.300 μs (119 allocations: 11.38 KiB)
  4.993 μs (119 allocations: 11.38 KiB)
true
```

# Todo

- [x] Docs
- [x] Should `WithTaskLocals` be exported?
- [x] Should `WithTaskLocals` be upstreamed to TaskLocalValues.jl? 
- [x] Any API/naming concerns?
