### PR TITLE
Add `SerialScheduler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ OhMyThreads.jl Changelog
 Version 0.5.0
 -------------
 
+- ![feature][badge-feature] Added a `SerialScheduler` that can be used to turn off any multithreading.
 - ![feature][badge-feature] Added `OhMyThreads.WithTaskLocals` that represents a closure over `TaskLocalValues`, but can have those values materialized as an optimization (using `OhMyThreads.promise_task_local`)
 - ![Enhancement][badge-enhancement] Made `@tasks` use `OhMyThreads.WithTaskLocals` automatically as an optimization.
 - ![Feature][badge-feature] In the case `nchunks > nthreads()`, the `StaticScheduler` now distributes chunks in a round-robin fashion (instead of either implicitly decreasing `nchunks` to `nthreads()` or throwing an error).

--- a/docs/src/refs/api.md
+++ b/docs/src/refs/api.md
@@ -32,6 +32,7 @@ Scheduler
 DynamicScheduler
 StaticScheduler
 GreedyScheduler
+SerialScheduler
 ```
 
 ## Non-Exported

--- a/src/OhMyThreads.jl
+++ b/src/OhMyThreads.jl
@@ -16,11 +16,12 @@ include("macros.jl")
 
 include("tools.jl")
 include("schedulers.jl")
-using .Schedulers: Scheduler, DynamicScheduler, StaticScheduler, GreedyScheduler
+using .Schedulers: Scheduler, DynamicScheduler, StaticScheduler, GreedyScheduler,
+                   SerialScheduler
 include("implementation.jl")
 
 export @tasks, @set, @local
 export treduce, tmapreduce, treducemap, tmap, tmap!, tforeach, tcollect
-export Scheduler, DynamicScheduler, StaticScheduler, GreedyScheduler
+export Scheduler, DynamicScheduler, StaticScheduler, GreedyScheduler, SerialScheduler
 
 end # module OhMyThreads

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -8,6 +8,7 @@ Supertype for all available schedulers:
 * [`DynamicScheduler`](@ref): default dynamic scheduler
 * [`StaticScheduler`](@ref): low-overhead static scheduler
 * [`GreedyScheduler`](@ref): greedy load-balancing scheduler
+* [`SerialScheduler`](@ref): serial (non-parallel) execution
 """
 abstract type Scheduler end
 
@@ -221,10 +222,19 @@ function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, s::GreedyScheduler)
     print(io, "└ Threadpool: default")
 end
 
+"""
+A scheduler for turning off any multithreading and running the code in serial. It aims to
+make parallel functions like, e.g., `tmapreduce(sin, +, 1:100)` behave like their serial
+counterparts, e.g., `mapreduce(sin, +, 1:100)`.
+"""
+struct SerialScheduler <: Scheduler
+end
+
 chunking_mode(s::Scheduler) = chunking_mode(typeof(s))
 chunking_mode(::Type{DynamicScheduler{C}}) where {C} = C
 chunking_mode(::Type{StaticScheduler{C}}) where {C} = C
 chunking_mode(::Type{GreedyScheduler}) = NoChunking
+chunking_mode(::Type{SerialScheduler}) = NoChunking
 
 chunking_enabled(s::Scheduler) = chunking_enabled(typeof(s))
 chunking_enabled(::Type{S}) where {S <: Scheduler} = chunking_mode(S) != NoChunking

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,13 +16,15 @@ sets_to_test = [(~ = isapprox, f = sin ∘ *, op = +,
     for (; ~, f, op, itrs, init) in sets_to_test
         @testset "f=$f, op=$op, itrs::$(typeof(itrs))" begin
             @testset for sched in (
-                StaticScheduler, DynamicScheduler, GreedyScheduler, DynamicScheduler{OhMyThreads.Schedulers.NoChunking})
+                StaticScheduler, DynamicScheduler, GreedyScheduler, DynamicScheduler{OhMyThreads.Schedulers.NoChunking}, SerialScheduler)
                 @testset for split in (:batch, :scatter)
                     for nchunks in (1, 2, 6)
                         if sched == GreedyScheduler
                             scheduler = sched(; ntasks = nchunks)
                         elseif sched == DynamicScheduler{OhMyThreads.Schedulers.NoChunking}
                             scheduler = DynamicScheduler(; nchunks = 0)
+                        elseif sched == SerialScheduler
+                            scheduler = SerialScheduler()
                         else
                             scheduler = sched(; nchunks, split)
                         end


### PR DESCRIPTION
Closes #69

E.g
```julia
julia> tmapreduce(+, 1:12; scheduler=SerialScheduler()) do i
           println(i, " → ", Threads.threadid())
           i
       end
1 → 1
2 → 1
3 → 1
4 → 1
5 → 1
6 → 1
7 → 1
8 → 1
9 → 1
10 → 1
11 → 1
12 → 1
78

julia> @btime tmapreduce(sin, +, 1:1000; scheduler=$(SerialScheduler()));
  19.824 μs (0 allocations: 0 bytes)

julia> @btime mapreduce(sin, +, 1:1000);
  19.833 μs (0 allocations: 0 bytes)
```