### PR TITLE
Disabling Chunking: unsupport `nchunks=0` in favor of `chunking=false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ OhMyThreads.jl Changelog
 Version 0.5.0
 -------------
 
-- ![feature][badge-feature] Added a `SerialScheduler` that can be used to turn off any multithreading.
-- ![feature][badge-feature] Added `OhMyThreads.WithTaskLocals` that represents a closure over `TaskLocalValues`, but can have those values materialized as an optimization (using `OhMyThreads.promise_task_local`)
+- ![Breaking][badge-breaking] `DynamicScheduler` and `StaticScheduler` don't support `nchunks=0` or `chunksize=0` any longer. Instead, chunking can now be turned off via an explicit new keyword argument `chunking=false`.
+- ![Feature][badge-feature] Added a `SerialScheduler` that can be used to turn off any multithreading.
+- ![Feature][badge-feature] Added `OhMyThreads.WithTaskLocals` that represents a closure over `TaskLocalValues`, but can have those values materialized as an optimization (using `OhMyThreads.promise_task_local`)
 - ![Enhancement][badge-enhancement] Made `@tasks` use `OhMyThreads.WithTaskLocals` automatically as an optimization.
 - ![Feature][badge-feature] In the case `nchunks > nthreads()`, the `StaticScheduler` now distributes chunks in a round-robin fashion (instead of either implicitly decreasing `nchunks` to `nthreads()` or throwing an error).
-- ![Feature][badge-feature] The `DynamicScheduler` (default) and the `StaticScheduler` now support a `chunksize` argument to specify the desired size of chunks instead of the number of chunks (`nchunks`). Note that `chunksize` and `nchunks` are mutually exclusive.
+- ![BREAKING][badge-breaking] The `DynamicScheduler` (default) and the `StaticScheduler` now support a `chunksize` argument to specify the desired size of chunks instead of the number of chunks (`nchunks`). Note that `chunksize` and `nchunks` are mutually exclusive. (This is unlikely to break existing code but technically could because the type parameter has changed from `Bool` to `ChunkingMode`.)
 - ![Feature][badge-feature] `@set init = ...` may now be used to specify an initial value for a reduction (only has an effect in conjuction with `@set reducer=...` and triggers a warning otherwise).
 - ![BREAKING][badge-breaking] Within a `@tasks` block, task-local values must from now on be defined via `@local` instead of `@init` (renamed).
 - ![BREAKING][badge-breaking] The (already deprecated) `SpawnAllScheduler` has been dropped.

--- a/src/macro_impl.jl
+++ b/src/macro_impl.jl
@@ -40,7 +40,7 @@ function tasks_macro(forex)
     q = if !isnothing(settings.reducer)
         quote
             $make_mapping_function
-            tmapreduce(mapping_function, $(settings.reducer), $(itrng); scheduler = $(settings.scheduler)) 
+            tmapreduce(mapping_function, $(settings.reducer), $(itrng); scheduler = $(settings.scheduler))
         end
     elseif settings.collect
         maybe_warn_useless_init(settings)


### PR DESCRIPTION
As discussed with @MasonProtter in private, it isn't entirely obvious what `nchunks=0` means - there are different possible interpretations - which is why we no longer support it. Instead, we introduce a new keyword argument `chunking` that can be used to toggle chunking.

Corresponding part of the docstring:

```
•  chunking::Bool (default true):
     • Controls whether input elements are grouped into chunks (true) or not (false).
     • For chunking=false, the arguments nchunks, chunksize, and split are ignored and input elements are
       regarded as "chunks" as is. Hence, there will be one parallel task spawned per input element. Note that,
       depending on the input, this might spawn many(!) tasks and can be costly!
```

Example:

```julia
julia> Threads.nthreads()
6

julia> tmapreduce(+, 1:12; scheduler=StaticScheduler(; chunking=false)) do i
           println(i, " → ", Threads.threadid())
           i
       end
3 → 3
4 → 4
9 → 3
10 → 4
2 → 2
6 → 6
8 → 2
5 → 5
12 → 6
11 → 5
1 → 1
7 → 1
78
```