### PR TITLE
Automatically infer TLS return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version 0.5.0
 - ![Feature][badge-feature] In the case `nchunks > nthreads()`, the `StaticScheduler` now distributes chunks in a round-robin fashion (instead of either implicitly decreasing `nchunks` to `nthreads()` or throwing an error).
 - ![Feature][badge-feature] `@set init = ...` may now be used to specify an initial value for a reduction (only has an effect in conjuction with `@set reducer=...` and triggers a warning otherwise).
 - ![Enhancement][badge-enhancement] Made `@tasks` use `OhMyThreads.WithTaskLocals` automatically as an optimization.
+- ![Enhancement][badge-enhancement] Uses of `@local` within no-longer require users to declare the type of the task local value, it is instead inferred automatically.
 - ![BREAKING][badge-breaking] The `DynamicScheduler` (default) and the `StaticScheduler` now support a `chunksize` argument to specify the desired size of chunks instead of the number of chunks (`nchunks`). Note that `chunksize` and `nchunks` are mutually exclusive. (This is unlikely to break existing code but technically could because the type parameter has changed from `Bool` to `ChunkingMode`.)
 - ![Breaking][badge-breaking] `DynamicScheduler` and `StaticScheduler` don't support `nchunks=0` or `chunksize=0` any longer. Instead, chunking can now be turned off via an explicit new keyword argument `chunking=false`.
 - ![BREAKING][badge-breaking] Within a `@tasks` block, task-local values must from now on be defined via `@local` instead of `@init` (renamed).

--- a/docs/src/literate/tls/tls.jl
+++ b/docs/src/literate/tls/tls.jl
@@ -174,7 +174,7 @@ function matmulsums_tlv_macro(As, Bs; kwargs...)
     N = size(first(As), 1)
     @tasks for i in eachindex(As,Bs)
         @set collect=true
-        @local C::Matrix{Float64} = Matrix{Float64}(undef, N, N)
+        @local C = Matrix{Float64}(undef, N, N)
         mul!(C, As[i], Bs[i])
         sum(C)
     end
@@ -183,9 +183,10 @@ end
 res_tlv_macro = matmulsums_tlv_macro(As, Bs)
 res ≈ res_tlv_macro
 
-# Here, `@local` expands to a pattern similar to the `TaskLocalValue` one above, although it
-# carries some optimizations (see [`OhMyThreads.WithTaskLocals`](@ref)) which can make accessing task
-# local values more efficient in loops which take on the order of 100ns to complete.
+# Here, `@local` expands to a pattern similar to the `TaskLocalValue` one above, although automatically
+# infers that the object's type is `Matrix{Float64}`, and it carries some optimizations (see 
+# [`OhMyThreads.WithTaskLocals`](@ref)) which can make accessing task local values more efficient in 
+# loops which take on the order of 100ns to complete.
 #
 #
 # ### Benchmark

--- a/docs/src/literate/tls/tls.md
+++ b/docs/src/literate/tls/tls.md
@@ -224,7 +224,7 @@ function matmulsums_tlv_macro(As, Bs; kwargs...)
     N = size(first(As), 1)
     @tasks for i in eachindex(As,Bs)
         @set collect=true
-        @local C::Matrix{Float64} = Matrix{Float64}(undef, N, N)
+        @local C = Matrix{Float64}(undef, N, N)
         mul!(C, As[i], Bs[i])
         sum(C)
     end
@@ -238,9 +238,10 @@ res ≈ res_tlv_macro
 true
 ````
 
-Here, `@local` expands to a pattern similar to the `TaskLocalValue` one above, although it
-carries some optimizations (see [`OhMyThreads.WithTaskLocals`](@ref)) which can make accessing task
-local values more efficient in loops which take on the order of 100ns to complete.
+Here, `@local` expands to a pattern similar to the `TaskLocalValue` one above, although automatically
+infers that the object's type is `Matrix{Float64}`, and it carries some optimizations (see 
+[`OhMyThreads.WithTaskLocals`](@ref)) which can make accessing task local values more efficient in 
+loops which take on the order of 100ns to complete.
 
 
 ### Benchmark

--- a/src/macro_impl.jl
+++ b/src/macro_impl.jl
@@ -127,6 +127,17 @@ function _unfold_atlocal_block(ex)
     return locals_before, locals_names
 end
 
+#=
+If the TLS doesn't have a declared return type, we're going to use `CC.return_type` to get it
+automatically. This would normally be non-kosher, but it's okay here for two reasons:
+1) The task local value *only* exists within the function being called, meaning that the worldage
+is frozen for the full lifetime of the TLV, so and `eval` can't change the outcome or cause incorrect inference.
+2) We do not allow users to *write* to the task local value, they can only retrieve its value, so there's no
+potential problems from the type being maximally narrow and then them trying to write a value of another type to it
+3) the task local value is not user-observable. we never let the user inspect its type, unless they themselves are
+using `code____` tools to inspect the generated code, hence if inference changes and gives a more or less precise
+type, there's no observable semantic changes, just performance increases or decreases. 
+=#
 function _atlocal_assign_to_exprs(ex)
     left_ex = ex.args[1]
     tls_def = esc(ex.args[2])

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -75,6 +75,8 @@ end
 
 @eval begin
     """
+        @local name = value
+
         @local name::T = value
     
     Can be used inside a `@tasks for ... end` block to specify
@@ -85,14 +87,14 @@ end
     There can only be a single `@local` block in a `@tasks for ... end` block. To specify
     multiple TLVs, use `@local begin ... end`. Compared to regular assignments, there are some
     limitations though, e.g. TLVs can't reference each other.
-    
+
     ## Examples
     
     ```julia
     using OhMyThreads.Tools: taskid
     @tasks for i in 1:10
         @set scheduler=DynamicScheduler(; nchunks=2)
-        @local x::Vector{Float64} = zeros(3) # TLV
+        @local x = zeros(3) # TLV
     
         x .+= 1
         println(taskid(), " -> ", x)
@@ -102,9 +104,18 @@ end
     ```julia
     @tasks for i in 1:10
         @local begin
-            x::Vector{Int64} = rand(Int, 3)
-            M::Matrix{Float64} = rand(3, 3)
+            x = rand(Int, 3)
+            M = rand(3, 3)
         end
+        # ...
+    end
+    ```
+
+    Task local variables created by `@local` are by default constrained to their inferred type,
+    but if you need to, you can specify a different type during declaration:
+    ```julia
+    @tasks for i in 1:10
+        @local x::Vector{Float64} = some_hard_to_infer_setup_function()
         # ...
     end
     ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -167,15 +167,15 @@ end
         x[]
     end) == 1.5 * ntd # if a new x would be allocated per iteration, we'd get ntd here.
     # TaskLocalValue (begin ... end block)
-    @test @tasks(for i in 1:10
+    @test @inferred (() -> @tasks for i in 1:10
         @local begin
             C::Matrix{Int64} = fill(4, 3, 3)
             x::Vector{Float64} = fill(5.0, 3)
         end
         @set reducer = (+)
         sum(C * x)
-    end) == 1800
-
+    end)() == 1800
+    
     # hygiene / escaping
     var = 3
     sched = StaticScheduler()


### PR DESCRIPTION
This makes it so that if you write
```julia
@tasks for i in itr
    @local x = f()
    # ...
end
```
inside a `@tasks` macro, then then that'll macroexpand to
```julia
let dinosaur = let porcupine = (()->f())
        OhMyThreads.TaskLocalValue{(OhMyThreads.Core).Compiler.return_type(porcupine, OhMyThreads.Tuple{})}(porcupine)
    end
    local octopus = OhMyThreads.WithTaskLocals((dinosaur,)) do (x,)
        function crane(i)
            #....
        end
    end
    OhMyThreads.tforeach(octopus, itr; scheduler = OhMyThreads.DynamicScheduler())
end
```
i.e. we're doing automatic type inference on `f()` so that the user doesn't have to declare a return type. This would normally be non-kosher, but it's okay here for two reasons:
1) The task local value *only* exists within the function being called, meaning that the worldage is frozen for the full lifetime of the TLV, so and `eval` can't change the outcome or cause incorrect inference:
```julia
julia> f() = 1;

julia> @tasks for i in 1:500
           @local x = f()
           @set reducer=(+)
           @set scheduler = DynamicScheduler(nchunks=2)
           @eval f() = 2.0
           x
       end
500

julia> @tasks for i in 1:500
           @local x = f()
           @set reducer=(+)
           @set scheduler = DynamicScheduler(nchunks=2)
           @eval f() = 2.0
           x
       end
1000.0
```

2) We do not allow users to *write* to the task local value, they can only retrieve its value, so there's no potential problems from the type being maximally narrow and then them trying to write a value of another type to it
3) the task local value is not user-observable. we never let the user inspect its type, unless they themselves are using `code____` tools to inspect the generated code, hence if inference changes and gives a more or less precise type, there's no observable semantic changes, just performance increases or decreases. 