### PR TITLE
Fix for `GreedyScheduler` in tests

### DIFF
--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -386,9 +386,6 @@ end
         _Arrs::AbstractArray...;
         scheduler::Scheduler = DynamicScheduler(),
         kwargs...)
-    if hasfield(typeof(scheduler), :split) && scheduler.split != :batch
-        error("Only `split == :batch` is supported because the parallel operation isn't commutative. (Scheduler: $scheduler)")
-    end
     Arrs = (A, _Arrs...)
     if scheduler isa SerialScheduler
         map!(f, out, Arrs...; kwargs...)


### PR DESCRIPTION
PR to change https://github.com/JuliaFolds2/OhMyThreads.jl/pull/77 since it was easier than using the code review options


This should get the tests passing on the new GreedyScheduler options, and fix an existing bug where `tmap!` would complain if you used `:batch` in it. We don't care about the re-ordering `Greedy` does for `tmap!` since the output array is already allocated and we are iterating over its indices. 