### PR TITLE
Full `scheduler::Symbol` support + Keyword argument forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Version 0.5.0
 - ![Breaking][badge-breaking] `DynamicScheduler` and `StaticScheduler` don't support `nchunks=0` or `chunksize=0` any longer. Instead, chunking can now be turned off via an explicit new keyword argument `chunking=false`.
 - ![BREAKING][badge-breaking] Within a `@tasks` block, task-local values must from now on be defined via `@local` instead of `@init` (renamed).
 - ![BREAKING][badge-breaking] The (already deprecated) `SpawnAllScheduler` has been dropped.
+- ![BREAKING][badge-breaking] The default value for `ntasks`/`nchunks` for `DynamicScheduler` has been changed from `2*nthreads()` to `nthreads()`. With the new value we now align with `@threads :dynamic`. The old value wasn't giving good load balancing anyways and choosing a higher value penalizes uniform use cases even more. To get the old behavior, set `nchunks=2*nthreads()`.
 
 Version 0.4.6
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ OhMyThreads.jl Changelog
 Version 0.5.0
 -------------
 
+- ![Feature][badge-feature] The parallel functions (e.g. tmapreduce etc.) now support `scheduler::Symbol` besides `scheduler::Scheduler`. To configure the selected scheduler (e.g. set `nchunks` etc.) one may now pass keyword arguments directly into the parallel functions (they will get passed on to the scheduler constructor). Example: `tmapreduce(sin, +, 1:10; chunksize=2, scheduler=:static)`. Analogous support has been added to the macro API: (Most) settings (`@set name = value`) will now be passed on to the parallel functions as keyword arguments (which then forward them to the scheduler constructor). Note that, to avoid ambiguity, we don't support this feature for `scheduler::Scheduler` but only for `scheduler::Symbol`.
 - ![Feature][badge-feature] Added a `SerialScheduler` that can be used to turn off any multithreading.
 - ![Feature][badge-feature] Added `OhMyThreads.WithTaskLocals` that represents a closure over `TaskLocalValues`, but can have those values materialized as an optimization (using `OhMyThreads.promise_task_local`)
 - ![Feature][badge-feature] In the case `nchunks > nthreads()`, the `StaticScheduler` now distributes chunks in a round-robin fashion (instead of either implicitly decreasing `nchunks` to `nthreads()` or throwing an error).
 - ![Feature][badge-feature] `@set init = ...` may now be used to specify an initial value for a reduction (only has an effect in conjuction with `@set reducer=...` and triggers a warning otherwise).
+- ![Enhancement][badge-enhancement] `SerialScheduler` and `DynamicScheduler` now support the keyword argument `ntasks` as an alias for `nchunks`.
 - ![Enhancement][badge-enhancement] Made `@tasks` use `OhMyThreads.WithTaskLocals` automatically as an optimization.
 - ![Enhancement][badge-enhancement] Uses of `@local` within `@tasks` no-longer require users to declare the type of the task local value, it can be inferred automatically if a type is not provided.
 - ![BREAKING][badge-breaking] The `DynamicScheduler` (default) and the `StaticScheduler` now support a `chunksize` argument to specify the desired size of chunks instead of the number of chunks (`nchunks`). Note that `chunksize` and `nchunks` are mutually exclusive. (This is unlikely to break existing code but technically could because the type parameter has changed from `Bool` to `ChunkingMode`.)

--- a/README.md
+++ b/README.md
@@ -38,11 +38,13 @@ focus on [data parallelism](https://en.wikipedia.org/wiki/Data_parallelism), tha
 ## Example
 
 ```julia
-using OhMyThreads
+using OhMyThreads: tmapreduce, @tasks
+using BenchmarkTools: @btime
+using Base.Threads: nthreads
 
 # Variant 1: function API
-function mc_parallel(N; kw...)
-    M = tmapreduce(+, 1:N; kw...) do i
+function mc_parallel(N; ntasks=nthreads())
+    M = tmapreduce(+, 1:N; ntasks) do i
         rand()^2 + rand()^2 < 1.0
     end
     pi = 4 * M / N
@@ -50,9 +52,12 @@ function mc_parallel(N; kw...)
 end
 
 # Variant 2: macro API
-function mc_parallel_macro(N)
+function mc_parallel_macro(N; ntasks=nthreads())
     M = @tasks for i in 1:N
-        @set reducer=+
+        @set begin
+            reducer=+
+            ntasks=ntasks
+        end
         rand()^2 + rand()^2 < 1.0
     end
     pi = 4 * M / N
@@ -62,19 +67,17 @@ end
 N = 100_000_000
 mc_parallel(N) # gives, e.g., 3.14159924
 
-using BenchmarkTools
-
-@show Threads.nthreads()                                        # 5 in this example
-
-@btime mc_parallel($N; scheduler=DynamicScheduler(; nchunks=1))   # effectively using 1 thread
-@btime mc_parallel($N)                                          # using all 5 threads
+@btime mc_parallel($N; ntasks=1) # use a single task (and hence a single thread)
+@btime mc_parallel($N)           # using all threads
+@btime mc_parallel_macro($N)     # using all threads
 ```
 
-Timings might be something like this:
+With 5 threads, timings might be something like this:
 
 ```
-447.093 ms (7 allocations: 624 bytes)
-89.401 ms (66 allocations: 5.72 KiB)
+417.282 ms (14 allocations: 912 bytes)
+83.578 ms (38 allocations: 3.08 KiB)
+83.573 ms (38 allocations: 3.08 KiB)
 ```
 
 (Check out the full [Parallel Monte Carlo](https://juliafolds2.github.io/OhMyThreads.jl/stable/literate/mc/mc/) example if you like.)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,7 +28,7 @@ makedocs(;
         ]
     ],
     repo = "https://github.com/JuliaFolds2/OhMyThreads.jl/blob/{commit}{path}#{line}",
-    format = Documenter.HTML(repolink = "https://github.com/JuliaFolds2/OhMyThreads.jl"))
+    format = Documenter.HTML(repolink = "https://github.com/JuliaFolds2/OhMyThreads.jl"; collapselevel = 1))
 
 if ci
     @info "Deploying documentation to GitHub"

--- a/docs/src/literate/integration/integration.jl
+++ b/docs/src/literate/integration/integration.jl
@@ -29,7 +29,6 @@ end
 # interval, as a multiple of the number of available Julia threads.
 
 using Base.Threads: nthreads
-@show nthreads()
 
 N = nthreads() * 1_000_000
 
@@ -82,3 +81,5 @@ using BenchmarkTools
 
 # Because the problem is trivially parallel - all threads to the same thing and don't need
 # to communicate - we expect an ideal speedup of (close to) the number of available threads.
+
+nthreads()

--- a/docs/src/literate/integration/integration.md
+++ b/docs/src/literate/integration/integration.md
@@ -46,13 +46,12 @@ interval, as a multiple of the number of available Julia threads.
 
 ````julia
 using Base.Threads: nthreads
-@show nthreads()
 
 N = nthreads() * 1_000_000
 ````
 
 ````
-5000000
+10000000
 ````
 
 Calling `trapezoidal` we do indeed find the (approximate) value of $\pi$.
@@ -101,6 +100,10 @@ end
 # end
 ````
 
+````
+trapezoidal_parallel (generic function with 1 method)
+````
+
 First, we check the correctness of our parallel implementation.
 
 ````julia
@@ -120,13 +123,21 @@ using BenchmarkTools
 ````
 
 ````
-  12.782 ms (0 allocations: 0 bytes)
-  2.563 ms (37 allocations: 3.16 KiB)
+  24.348 ms (0 allocations: 0 bytes)
+  2.457 ms (69 allocations: 6.05 KiB)
 
 ````
 
 Because the problem is trivially parallel - all threads to the same thing and don't need
 to communicate - we expect an ideal speedup of (close to) the number of available threads.
+
+````julia
+nthreads()
+````
+
+````
+10
+````
 
 ---
 

--- a/docs/src/literate/juliaset/juliaset.jl
+++ b/docs/src/literate/juliaset/juliaset.jl
@@ -111,12 +111,12 @@ img = zeros(Int, N, N)
 # the load balancing of the default dynamic scheduler. The latter divides the overall
 # workload into tasks that can then be dynamically distributed among threads to adjust the
 # per-thread load. We can try to fine tune and improve the load balancing further by
-# increasing the `nchunks` parameter of the scheduler, that is, creating more and smaller
-# tasks.
+# increasing the `ntasks` parameter of the scheduler, that is, creating more tasks with
+# smaller per-task workload.
 
 using OhMyThreads: DynamicScheduler
 
-@btime compute_juliaset_parallel!($img; scheduler=DynamicScheduler(; nchunks=N)) samples=10 evals=3;
+@btime compute_juliaset_parallel!($img; ntasks=N, scheduler=:dynamic) samples=10 evals=3;
 
 # Note that while this turns out to be a bit faster, it comes at the expense of much more
 # allocations.
@@ -126,4 +126,4 @@ using OhMyThreads: DynamicScheduler
 
 using OhMyThreads: StaticScheduler
 
-@btime compute_juliaset_parallel!($img; scheduler=StaticScheduler()) samples=10 evals=3;
+@btime compute_juliaset_parallel!($img; scheduler=:static) samples=10 evals=3;

--- a/docs/src/literate/juliaset/juliaset.md
+++ b/docs/src/literate/juliaset/juliaset.md
@@ -121,9 +121,9 @@ img = zeros(Int, N, N)
 ````
 
 ````
-nthreads() = 5
-  138.157 ms (0 allocations: 0 bytes)
-  40.373 ms (67 allocations: 6.20 KiB)
+nthreads() = 10
+  131.295 ms (0 allocations: 0 bytes)
+  31.422 ms (68 allocations: 6.09 KiB)
 
 ````
 
@@ -135,17 +135,17 @@ As stated above, the per-pixel computation is non-uniform. Hence, we do benefit 
 the load balancing of the default dynamic scheduler. The latter divides the overall
 workload into tasks that can then be dynamically distributed among threads to adjust the
 per-thread load. We can try to fine tune and improve the load balancing further by
-increasing the `nchunks` parameter of the scheduler, that is, creating more and smaller
-tasks.
+increasing the `ntasks` parameter of the scheduler, that is, creating more tasks with
+smaller per-task workload.
 
 ````julia
 using OhMyThreads: DynamicScheduler
 
-@btime compute_juliaset_parallel!($img; scheduler=DynamicScheduler(; nchunks=N)) samples=10 evals=3;
+@btime compute_juliaset_parallel!($img; ntasks=N, scheduler=:dynamic) samples=10 evals=3;
 ````
 
 ````
-  31.751 ms (12011 allocations: 1.14 MiB)
+  17.438 ms (12018 allocations: 1.11 MiB)
 
 ````
 
@@ -158,11 +158,11 @@ To quantify the impact of load balancing we can opt out of dynamic scheduling an
 ````julia
 using OhMyThreads: StaticScheduler
 
-@btime compute_juliaset_parallel!($img; scheduler=StaticScheduler()) samples=10 evals=3;
+@btime compute_juliaset_parallel!($img; scheduler=:static) samples=10 evals=3;
 ````
 
 ````
-  63.147 ms (37 allocations: 3.26 KiB)
+  30.097 ms (73 allocations: 6.23 KiB)
 
 ````
 

--- a/docs/src/literate/mc/mc.jl
+++ b/docs/src/literate/mc/mc.jl
@@ -74,8 +74,8 @@ using Base.Threads: nthreads
 
 using OhMyThreads: StaticScheduler
 
-@btime mc_parallel($N) samples=10 evals=3;
-@btime mc_parallel($N; scheduler = StaticScheduler()) samples=10 evals=3;
+@btime mc_parallel($N; scheduler=:dynamic) samples=10 evals=3; # default
+@btime mc_parallel($N; scheduler=:static) samples=10 evals=3;
 
 # ## Manual parallelization
 #

--- a/docs/src/literate/mc/mc.md
+++ b/docs/src/literate/mc/mc.md
@@ -34,7 +34,7 @@ mc(N)
 ````
 
 ````
-3.14145748
+3.14171236
 ````
 
 ## Parallelization with `tmapreduce`
@@ -69,7 +69,7 @@ mc_parallel(N)
 ````
 
 ````
-3.14134792
+3.14156496
 ````
 
 Let's run a quick benchmark.
@@ -86,9 +86,9 @@ using Base.Threads: nthreads
 ````
 
 ````
-nthreads() = 5
-  317.745 ms (0 allocations: 0 bytes)
-  88.384 ms (66 allocations: 5.72 KiB)
+nthreads() = 10
+  301.636 ms (0 allocations: 0 bytes)
+  41.864 ms (68 allocations: 5.81 KiB)
 
 ````
 
@@ -100,13 +100,13 @@ and compare the performance of static and dynamic scheduling (with default param
 ````julia
 using OhMyThreads: StaticScheduler
 
-@btime mc_parallel($N) samples=10 evals=3;
-@btime mc_parallel($N; scheduler=StaticScheduler()) samples=10 evals=3;
+@btime mc_parallel($N; scheduler=:dynamic) samples=10 evals=3; # default
+@btime mc_parallel($N; scheduler=:static) samples=10 evals=3;
 ````
 
 ````
-  88.222 ms (66 allocations: 5.72 KiB)
-  88.203 ms (36 allocations: 2.98 KiB)
+  41.839 ms (68 allocations: 5.81 KiB)
+  41.838 ms (68 allocations: 5.81 KiB)
 
 ````
 
@@ -121,7 +121,7 @@ simulation. Finally, we fetch the results and compute the average estimate for $
 using OhMyThreads: @spawn, chunks
 
 function mc_parallel_manual(N; nchunks = nthreads())
-    tasks = map(chunks(1:N; n = nchunks)) do idcs # TODO: replace by `tmap` once ready
+    tasks = map(chunks(1:N; n = nchunks)) do idcs
         @spawn mc(length(idcs))
     end
     pi = sum(fetch, tasks) / nchunks
@@ -132,7 +132,7 @@ mc_parallel_manual(N)
 ````
 
 ````
-3.1414609999999996
+3.14180504
 ````
 
 And this is the performance:
@@ -142,7 +142,7 @@ And this is the performance:
 ````
 
 ````
-  64.042 ms (31 allocations: 2.80 KiB)
+  30.224 ms (65 allocations: 5.70 KiB)
 
 ````
 
@@ -161,8 +161,8 @@ end samples=10 evals=3;
 ````
 
 ````
-  88.041 ms (0 allocations: 0 bytes)
-  63.427 ms (0 allocations: 0 bytes)
+  41.750 ms (0 allocations: 0 bytes)
+  30.148 ms (0 allocations: 0 bytes)
 
 ````
 

--- a/docs/src/literate/tls/tls.jl
+++ b/docs/src/literate/tls/tls.jl
@@ -172,8 +172,8 @@ using OhMyThreads: @tasks
 
 function matmulsums_tlv_macro(As, Bs; kwargs...)
     N = size(first(As), 1)
-    @tasks for i in eachindex(As,Bs)
-        @set collect=true
+    @tasks for i in eachindex(As, Bs)
+        @set collect = true
         @local C = Matrix{Float64}(undef, N, N)
         mul!(C, As[i], Bs[i])
         sum(C)
@@ -184,8 +184,8 @@ res_tlv_macro = matmulsums_tlv_macro(As, Bs)
 res ≈ res_tlv_macro
 
 # Here, `@local` expands to a pattern similar to the `TaskLocalValue` one above, although automatically
-# infers that the object's type is `Matrix{Float64}`, and it carries some optimizations (see 
-# [`OhMyThreads.WithTaskLocals`](@ref)) which can make accessing task local values more efficient in 
+# infers that the object's type is `Matrix{Float64}`, and it carries some optimizations (see
+# [`OhMyThreads.WithTaskLocals`](@ref)) which can make accessing task local values more efficient in
 # loops which take on the order of 100ns to complete.
 #
 #
@@ -211,23 +211,7 @@ sleep(2) #hide
 # As we can see, `matmulsums_tlv` (and `matmulsums_tlv_macro`) isn't only convenient
 # but also efficient: It allocates much less memory than `matmulsums_naive` and is about on
 # par with the manual implementation.
-
-# #### Tuning the scheduling
 #
-# Since the workload is uniform, we don't need load balancing. We can thus try to improve
-# the performance and reduce the number of allocations by choosing the number of chunks
-# (i.e. tasks) to match the number of Julia threads. Concretely, this
-# amounts to passing in `DynamicScheduler(; nchunks=nthreads())`. If we further want to
-# opt-out of dynamic scheduling alltogether, we can choose the `StaticScheduler()`.
-
-using OhMyThreads: DynamicScheduler, StaticScheduler
-
-@btime matmulsums_tlv(
-    $As, $Bs; scheduler = $(DynamicScheduler(; nchunks = nthreads())));
-@btime matmulsums_tlv($As, $Bs; scheduler = $(StaticScheduler()));
-
-# Interestingly, this doesn't always lead to speedups (maybe even a slight slowdown).
-
 #
 # ## Per-thread allocation
 #
@@ -285,13 +269,14 @@ res_nu ≈ res_pt_naive
 # ### The quick fix (with caveats)
 #
 # A simple solution for the task-migration issue is to opt-out of dynamic scheduling with
-# the `StaticScheduler()`. This scheduler statically assigns tasks to threads
-# upfront without any dynamic rescheduling (the tasks are sticky and won't migrate).
+# `scheduler=:static` (or `scheduler=StaticScheduler()`). This scheduler statically
+# assigns tasks to threads upfront without any dynamic rescheduling
+# (the tasks are sticky and won't migrate).
 #
 function matmulsums_perthread_static(As, Bs)
     N = size(first(As), 1)
     Cs = [Matrix{Float64}(undef, N, N) for _ in 1:nthreads()]
-    tmap(As, Bs; scheduler = StaticScheduler()) do A, B
+    tmap(As, Bs; scheduler = :static) do A, B
         C = Cs[threadid()]
         mul!(C, A, B)
         sum(C)
@@ -336,27 +321,21 @@ res_nu ≈ res_pt_channel
 # ### Benchmark
 #
 # Let's benchmark the variants above and compare them to the task-local implementation.
-# We want to look at both `nchunks = nthreads()` and `nchunks > nthreads()`, the latter
+# We want to look at both `ntasks = nthreads()` and `ntasks > nthreads()`, the latter
 # of which gives us dynamic load balancing.
 #
 
-## no load balancing because nchunks == nthreads()
-@btime matmulsums_tlv($As_nu, $Bs_nu;
-    scheduler = $(DynamicScheduler(; nchunks = nthreads())));
+## no load balancing because ntasks == nthreads()
+@btime matmulsums_tlv($As_nu, $Bs_nu);
 @btime matmulsums_perthread_static($As_nu, $Bs_nu);
-@btime matmulsums_perthread_channel($As_nu, $Bs_nu;
-    scheduler = $(DynamicScheduler(; nchunks = nthreads())));
+@btime matmulsums_perthread_channel($As_nu, $Bs_nu);
 
-## load balancing because nchunks > nthreads()
-@btime matmulsums_tlv($As_nu, $Bs_nu;
-    scheduler = $(DynamicScheduler(; nchunks = 2 * nthreads())));
-@btime matmulsums_perthread_channel($As_nu, $Bs_nu;
-    scheduler = $(DynamicScheduler(; nchunks = 2 * nthreads())));
+## load balancing because ntasks > nthreads()
+@btime matmulsums_tlv($As_nu, $Bs_nu; ntasks = 2 * nthreads());
+@btime matmulsums_perthread_channel($As_nu, $Bs_nu; ntasks = 2 * nthreads());
 
-@btime matmulsums_tlv($As_nu, $Bs_nu;
-    scheduler = $(DynamicScheduler(; nchunks = 10 * nthreads())));
-@btime matmulsums_perthread_channel($As_nu, $Bs_nu;
-    scheduler = $(DynamicScheduler(; nchunks = 10 * nthreads())));
+@btime matmulsums_tlv($As_nu, $Bs_nu; ntasks = 10 * nthreads());
+@btime matmulsums_perthread_channel($As_nu, $Bs_nu; ntasks = 10 * nthreads());
 
 #
 # Note that the runtime of `matmulsums_perthread_channel` improves with increasing number
@@ -371,14 +350,15 @@ res_nu ≈ res_pt_channel
 # a limited number of tasks (e.g. `nthreads()`) with task-local buffers.
 #
 using OhMyThreads: tmapreduce
+
 function matmulsums_perthread_channel_flipped(As, Bs; ntasks = nthreads())
     N = size(first(As), 1)
-    chnl = Channel{Int}(length(As); spawn=true) do chnl
+    chnl = Channel{Int}(length(As); spawn = true) do chnl
         for i in 1:length(As)
             put!(chnl, i)
         end
     end
-    tmapreduce(vcat, 1:ntasks; scheduler = DynamicScheduler(; nchunks = 0)) do _ # we turn chunking off
+    tmapreduce(vcat, 1:ntasks; chunking=false) do _ # we turn chunking off
         local C = Matrix{Float64}(undef, N, N)
         map(chnl) do i # implicitly takes the values from the channel (parallel safe)
             A = As[i]
@@ -408,7 +388,7 @@ sort(res_nu) ≈ sort(res_channel_flipped)
 # give [Bumper.jl](https://github.com/MasonProtter/Bumper.jl) a try. Essentially, it
 # allows you to *bring your own stacks*, that is, task-local bump allocators which you can
 # dynamically allocate memory to, and reset them at the end of a code block, just like
-# Julia's stack. 
+# Julia's stack.
 # Be warned though that Bumper.jl is (1) a rather young package with (likely) some bugs
 # and (2) can easily lead to segfaults when used incorrectly. If you can live with the
 # risk, Bumper.jl is especially useful for causes  we don't know ahead of time how large
@@ -430,7 +410,7 @@ function matmulsums_bumper(As, Bs)
 end
 
 res_bumper = matmulsums_bumper(As, Bs);
-sort(res_nu) ≈ sort(res_bumper)
+sort(res) ≈ sort(res_bumper)
 
 @btime matmulsums_bumper($As, $Bs);
 

--- a/docs/src/translation.md
+++ b/docs/src/translation.md
@@ -45,7 +45,7 @@ end
 
 # or
 
-tforeach(1:10; scheduler=StaticScheduler()) do i
+tforeach(1:10; scheduler=:static) do i
     println(i)
 end
 ```
@@ -62,13 +62,13 @@ end
 ```julia
 # OhMyThreads
 @tasks for i in 1:10
-    @set scheduler=DynamicScheduler(; nchunks=0) # turn off chunking
+    @set chunking=false
     println(i)
 end
 
 # or
 
-tforeach(1:10; scheduler=DynamicScheduler(; nchunks=0)) do i
+tforeach(1:10; chunking=false) do i
     println(i)
 end
 ```

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1,6 +1,6 @@
 """
     tmapreduce(f, op, A::AbstractArray...;
-               [scheduler::Scheduler = DynamicScheduler()],
+               [scheduler::Union{Scheduler, Symbol} = :dynamic],
                [outputtype::Type = Any],
                [init])
 
@@ -27,15 +27,23 @@ is the parallelized version of `sum(√, [1, 2, 3, 4, 5])` in the form
 
 ## Keyword arguments:
 
-- `scheduler::Scheduler` (default `DynamicScheduler()`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information.
-- `outputtype::Type` (default `Any`): will work as the asserted output type of parallel calculations. We use [StableTasks.jl](https://github.com/MasonProtter/StableTasks.jl) to make setting this option unnecessary, but if you experience problems with type stability, you may be able to recover it with this keyword argument.
-- `init`: forwarded to `mapreduce` for the task-local sequential parts of the calculation.
+- `scheduler::Union{Scheduler, Symbol}` (default `:dynamic`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information on the available schedulers.
+- `outputtype::Type` (default `Any`): will work as the asserted output type of parallel calculations. We use [StableTasks.jl](https://github.com/JuliaFolds2/StableTasks.jl) to make setting this option unnecessary, but if you experience problems with type stability, you may be able to recover it with this keyword argument.
+- `init`: initial value of the reduction. Will be forwarded to `mapreduce` for the task-local sequential parts of the calculation.
+
+In addition, `tmapreduce` accepts **all keyword arguments that are supported by the selected
+scheduler**. They will simply be passed on to the corresponding `Scheduler` constructor. Example:
+```
+tmapreduce(√, +, [1, 2, 3, 4, 5]; chunksize=2, scheduler=:static)
+```
+However, to avoid ambiguity, this is currently **only supported for `scheduler::Symbol`**
+(but not for `scheduler::Scheduler`).
 """
 function tmapreduce end
 
 """
     treducemap(op, f, A::AbstractArray...;
-               [scheduler::Scheduler = DynamicScheduler()],
+               [scheduler::Union{Scheduler, Symbol} = :dynamic],
                [outputtype::Type = Any],
                [init])
 
@@ -52,7 +60,7 @@ will get undefined results.
 ## Example:
 
 ```
-tmapreduce(√, +, [1, 2, 3, 4, 5])
+treducemap(+, √, [1, 2, 3, 4, 5])
 ```
 
 is the parallelized version of `sum(√, [1, 2, 3, 4, 5])` in the form
@@ -63,15 +71,23 @@ is the parallelized version of `sum(√, [1, 2, 3, 4, 5])` in the form
 
 ## Keyword arguments:
 
-- `scheduler::Scheduler` (default `DynamicScheduler()`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information.
-- `outputtype::Type` (default `Any`): will work as the asserted output type of parallel calculations. We use [StableTasks.jl](https://github.com/MasonProtter/StableTasks.jl) to make setting this option unnecessary, but if you experience problems with type stability, you may be able to recover it with this keyword argument.
-- `init`: forwarded to `mapreduce` for the task-local sequential parts of the calculation.
+- `scheduler::Union{Scheduler, Symbol}` (default `:dynamic`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information on the available schedulers.
+- `outputtype::Type` (default `Any`): will work as the asserted output type of parallel calculations. We use [StableTasks.jl](https://github.com/JuliaFolds2/StableTasks.jl) to make setting this option unnecessary, but if you experience problems with type stability, you may be able to recover it with this keyword argument.
+- `init`: initial value of the reduction. Will be forwarded to `mapreduce` for the task-local sequential parts of the calculation.
+
+In addition, `treducemap` accepts **all keyword arguments that are supported by the selected
+scheduler**. They will simply be passed on to the corresponding `Scheduler` constructor. Example:
+```
+treducemap(+, √, [1, 2, 3, 4, 5]; chunksize=2, scheduler=:static)
+```
+However, to avoid ambiguity, this is currently **only supported for `scheduler::Symbol`**
+(but not for `scheduler::Scheduler`).
 """
 function treducemap end
 
 """
     treduce(op, A::AbstractArray...;
-            [scheduler::Scheduler = DynamicScheduler()],
+            [scheduler::Union{Scheduler, Symbol} = :dynamic],
             [outputtype::Type = Any],
             [init])
 
@@ -97,15 +113,23 @@ is the parallelized version of `sum([1, 2, 3, 4, 5])` in the form
 
 ## Keyword arguments:
 
-- `scheduler::Scheduler` (default `DynamicScheduler()`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information.
-- `outputtype::Type` (default `Any`): will work as the asserted output type of parallel calculations. We use [StableTasks.jl](https://github.com/MasonProtter/StableTasks.jl) to make setting this option unnecessary, but if you experience problems with type stability, you may be able to recover it with this keyword argument.
-- `init`: forwarded to `mapreduce` for the task-local sequential parts of the calculation.
+- `scheduler::Union{Scheduler, Symbol}` (default `:dynamic`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information on the available schedulers.
+- `outputtype::Type` (default `Any`): will work as the asserted output type of parallel calculations. We use [StableTasks.jl](https://github.com/JuliaFolds2/StableTasks.jl) to make setting this option unnecessary, but if you experience problems with type stability, you may be able to recover it with this keyword argument.
+- `init`: initial value of the reduction. Will be forwarded to `mapreduce` for the task-local sequential parts of the calculation.
+
+In addition, `treduce` accepts **all keyword arguments that are supported by the selected
+scheduler**. They will simply be passed on to the corresponding `Scheduler` constructor. Example:
+```
+treduce(+, [1, 2, 3, 4, 5]; chunksize=2, scheduler=:static)
+```
+However, to avoid ambiguity, this is currently **only supported for `scheduler::Symbol`**
+(but not for `scheduler::Scheduler`).
 """
 function treduce end
 
 """
     tforeach(f, A::AbstractArray...;
-             [schedule::Scheduler = DynamicScheduler()]) :: Nothing
+             [schedule::Union{Scheduler, Symbol} = :dynamic]) :: Nothing
 
 A multithreaded function like `Base.foreach`. Apply `f` to each element of `A` on
 multiple parallel tasks, and return `nothing`. I.e. it is the parallel equivalent of
@@ -126,13 +150,23 @@ end
 
 ## Keyword arguments:
 
-- `scheduler::Scheduler` (default `DynamicScheduler()`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information.
+- `scheduler::Union{Scheduler, Symbol}` (default `:dynamic`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information on the available schedulers.
+
+In addition, `tforeach` accepts **all keyword arguments that are supported by the selected
+scheduler**. They will simply be passed on to the corresponding `Scheduler` constructor. Example:
+```
+tforeach(1:10; chunksize=2, scheduler=:static) do i
+    println(i^2)
+end
+```
+However, to avoid ambiguity, this is currently **only supported for `scheduler::Symbol`**
+(but not for `scheduler::Scheduler`).
 """
 function tforeach end
 
 """
     tmap(f, [OutputElementType], A::AbstractArray...;
-         [schedule::Scheduler = DynamicScheduler()])
+         [schedule::Union{Scheduler, Symbol} = :dynamic])
 
 A multithreaded function like `Base.map`. Create a new container `similar` to `A` and fills
 it in parallel such that the `i`th element is equal to `f(A[i])`.
@@ -149,26 +183,39 @@ tmap(sin, 1:10)
 
 ## Keyword arguments:
 
-- `scheduler::Scheduler` (default `DynamicScheduler()`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information.
+- `scheduler::Union{Scheduler, Symbol}` (default `:dynamic`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information on the available schedulers.
+
+In addition, `tmap` accepts **all keyword arguments that are supported by the selected
+scheduler**. They will simply be passed on to the corresponding `Scheduler` constructor. Example:
+```
+tmap(sin, 1:10; chunksize=2, scheduler=:static)
+```
+However, to avoid ambiguity, this is currently **only supported for `scheduler::Symbol`**
+(but not for `scheduler::Scheduler`).
 """
 function tmap end
 
 """
     tmap!(f, out, A::AbstractArray...;
-          [schedule::Scheduler = DynamicScheduler()])
+          [schedule::Union{Scheduler, Symbol} = :dynamic])
 
 A multithreaded function like `Base.map!`. In parallel on multiple tasks, this function
 assigns each element of `out[i] = f(A[i])` for each index `i` of `A` and `out`.
 
 ## Keyword arguments:
 
-- `scheduler::Scheduler` (default `DynamicScheduler()`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information.
+- `scheduler::Union{Scheduler, Symbol}` (default `:dynamic`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information on the available schedulers.
+
+In addition, `tmap!` accepts **all keyword arguments that are supported by the selected
+scheduler**. They will simply be passed on to the corresponding `Scheduler` constructor.
+However, to avoid ambiguity, this is currently **only supported for `scheduler::Symbol`**
+(but not for `scheduler::Scheduler`).
 """
 function tmap! end
 
 """
     tcollect([OutputElementType], gen::Union{AbstractArray, Generator{<:AbstractArray}};
-             [schedule::Scheduler = DynamicScheduler()])
+             [schedule::Union{Scheduler, Symbol} = :dynamic])
 
 A multithreaded function like `Base.collect`. Essentially just calls `tmap` on the
 generator function and inputs.
@@ -185,6 +232,14 @@ tcollect(sin(i) for i in 1:10)
 
 ## Keyword arguments:
 
-- `scheduler::Scheduler` (default `DynamicScheduler()`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information.
+- `scheduler::Union{Scheduler, Symbol}` (default `:dynamic`): determines how the computation is divided into parallel tasks and how these are scheduled. See [`Scheduler`](@ref) for more information on the available schedulers.
+
+In addition, `tcollect` accepts **all keyword arguments that are supported by the selected
+scheduler**. They will simply be passed on to the corresponding `Scheduler` constructor. Example:
+```
+tcollect(sin(i) for i in 1:10; chunksize=2, scheduler=:static)
+```
+However, to avoid ambiguity, this is currently **only supported for `scheduler::Symbol`**
+(but not for `scheduler::Scheduler`).
 """
 function tcollect end

--- a/src/macro_impl.jl
+++ b/src/macro_impl.jl
@@ -62,6 +62,9 @@ function tasks_macro(forex)
     if isgiven(settings.scheduler)
         push!(kwexpr.args, Expr(:kw, :scheduler, settings.scheduler))
     end
+    if isgiven(settings.init)
+        push!(kwexpr.args, Expr(:kw, :init, settings.init))
+    end
     for (k, v) in settings.kwargs
         push!(kwexpr.args, Expr(:kw, k, v))
     end

--- a/src/macro_impl.jl
+++ b/src/macro_impl.jl
@@ -140,7 +140,7 @@ is frozen for the full lifetime of the TLV, so and `eval` can't change the outco
 potential problems from the type being maximally narrow and then them trying to write a value of another type to it
 3) the task local value is not user-observable. we never let the user inspect its type, unless they themselves are
 using `code____` tools to inspect the generated code, hence if inference changes and gives a more or less precise
-type, there's no observable semantic changes, just performance increases or decreases. 
+type, there's no observable semantic changes, just performance increases or decreases.
 =#
 function _atlocal_assign_to_exprs(ex)
     left_ex = ex.args[1]
@@ -198,6 +198,6 @@ function _handle_atset_single_assign!(settings, ex)
         def = def isa Bool ? def : esc(def)
         setfield!(settings, sym, def)
     else
-        push!(settings.kwargs, sym => def)
+        push!(settings.kwargs, sym => esc(def))
     end
 end

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -2,6 +2,12 @@ module Schedulers
 
 using Base.Threads: nthreads
 
+# Used to indicate that a keyword argument has not been set by the user.
+# We don't use Nothing because nothing maybe sometimes be a valid user input (e.g. for init)
+struct NotGiven end
+isgiven(::NotGiven) = false
+isgiven(::T) where {T} = true
+
 const MaybeInteger = Union{Integer, Nothing}
 
 """

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -8,7 +8,7 @@ struct NotGiven end
 isgiven(::NotGiven) = false
 isgiven(::T) where {T} = true
 
-const MaybeInteger = Union{Integer, Nothing}
+const MaybeInteger = Union{Integer, NotGiven}
 
 """
 Supertype for all available schedulers:
@@ -95,9 +95,9 @@ end
 
 function DynamicScheduler(;
         threadpool::Symbol = :default,
-        nchunks::MaybeInteger = nothing,
-        ntasks::MaybeInteger = nothing, # "alias" for nchunks
-        chunksize::MaybeInteger = nothing,
+        nchunks::MaybeInteger = NotGiven(),
+        ntasks::MaybeInteger = NotGiven(), # "alias" for nchunks
+        chunksize::MaybeInteger = NotGiven(),
         chunking::Bool = true,
         split::Symbol = :batch)
     if !chunking
@@ -105,16 +105,16 @@ function DynamicScheduler(;
         chunksize = -1
     else
         # only choose nchunks default if chunksize hasn't been specified
-        if isnothing(nchunks) && isnothing(chunksize) && isnothing(ntasks)
+        if !isgiven(nchunks) && !isgiven(chunksize) && !isgiven(ntasks)
             nchunks = 2 * nthreads(threadpool)
             chunksize = -1
         else
-            if !isnothing(nchunks) && !isnothing(ntasks)
+            if isgiven(nchunks) && isgiven(ntasks)
                 throw(ArgumentError("nchunks and ntasks are aliases and only one may be provided"))
             end
-            nchunks = !isnothing(nchunks) ? nchunks :
-                      !isnothing(ntasks) ? ntasks : -1
-            chunksize = isnothing(chunksize) ? -1 : chunksize
+            nchunks = isgiven(nchunks) ? nchunks :
+                      isgiven(ntasks) ? ntasks : -1
+            chunksize = isgiven(chunksize) ? chunksize : -1
         end
     end
     DynamicScheduler(threadpool, nchunks, chunksize, split; chunking)
@@ -179,9 +179,9 @@ struct StaticScheduler{C <: ChunkingMode} <: Scheduler
 end
 
 function StaticScheduler(;
-        nchunks::MaybeInteger = nothing,
-        ntasks::MaybeInteger = nothing, # "alias" for nchunks
-        chunksize::MaybeInteger = nothing,
+        nchunks::MaybeInteger = NotGiven(),
+        ntasks::MaybeInteger = NotGiven(), # "alias" for nchunks
+        chunksize::MaybeInteger = NotGiven(),
         chunking::Bool = true,
         split::Symbol = :batch)
     if !chunking
@@ -189,16 +189,16 @@ function StaticScheduler(;
         chunksize = -1
     else
         # only choose nchunks default if chunksize hasn't been specified
-        if isnothing(nchunks) && isnothing(chunksize) && isnothing(ntasks)
+        if !isgiven(nchunks) && !isgiven(chunksize) && !isgiven(ntasks)
             nchunks = nthreads(:default)
             chunksize = -1
         else
-            if !isnothing(nchunks) && !isnothing(ntasks)
+            if isgiven(nchunks) && isgiven(ntasks)
                 throw(ArgumentError("nchunks and ntasks are aliases and only one may be provided"))
             end
-            nchunks = !isnothing(nchunks) ? nchunks :
-                      !isnothing(ntasks) ? ntasks : -1
-            chunksize = isnothing(chunksize) ? -1 : chunksize
+            nchunks = isgiven(nchunks) ? nchunks :
+                      isgiven(ntasks) ? ntasks : -1
+            chunksize = isgiven(chunksize) ? chunksize : -1
         end
     end
     StaticScheduler(nchunks, chunksize, split; chunking)

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -37,6 +37,8 @@ function _chunkingstr(s::Scheduler)
 end
 
 """
+    DynamicScheduler (aka :dynamic)
+
 The default dynamic scheduler. Divides the given collection into chunks and
 then spawns a task per chunk to perform the requested operation in parallel.
 The tasks are assigned to threads by Julia's dynamic scheduler and are non-sticky, that is,
@@ -123,6 +125,8 @@ function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, s::DynamicScheduler
 end
 
 """
+    StaticScheduler (aka :static)
+
 A static low-overhead scheduler. Divides the given collection into chunks and
 then spawns a task per chunk to perform the requested operation in parallel.
 The tasks are statically assigned to threads up front and are made *sticky*, that is,
@@ -202,6 +206,8 @@ function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, s::StaticScheduler)
 end
 
 """
+    GreedyScheduler (aka :greedy)
+
 A greedy dynamic scheduler. The elements of the collection are first put into a `Channel`
 and then dynamic, non-sticky tasks are spawned to process channel content in parallel.
 
@@ -234,6 +240,8 @@ function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, s::GreedyScheduler)
 end
 
 """
+    SerialScheduler (aka :serial)
+
 A scheduler for turning off any multithreading and running the code in serial. It aims to
 make parallel functions like, e.g., `tmapreduce(sin, +, 1:100)` behave like their serial
 counterparts, e.g., `mapreduce(sin, +, 1:100)`.

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -49,7 +49,7 @@ with other multithreaded code.
 
 ## Keyword arguments:
 
-- `nchunks::Integer` or `ntasks::Integer` (default `2 * nthreads(threadpool)`):
+- `nchunks::Integer` or `ntasks::Integer` (default `nthreads(threadpool)`):
     * Determines the number of chunks (and thus also the number of parallel tasks).
     * Increasing `nchunks` can help with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead. For `nchunks <= nthreads()` there are not enough chunks for any load balancing.
     * Setting `nchunks < nthreads()` is an effective way to use only a subset of the available threads.
@@ -106,7 +106,7 @@ function DynamicScheduler(;
     else
         # only choose nchunks default if chunksize hasn't been specified
         if !isgiven(nchunks) && !isgiven(chunksize) && !isgiven(ntasks)
-            nchunks = 2 * nthreads(threadpool)
+            nchunks = nthreads(threadpool)
             chunksize = -1
         else
             if isgiven(nchunks) && isgiven(ntasks)

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -109,6 +109,9 @@ function DynamicScheduler(;
             nchunks = 2 * nthreads(threadpool)
             chunksize = -1
         else
+            if !isnothing(nchunks) && !isnothing(ntasks)
+                throw(ArgumentError("nchunks and ntasks are aliases and only one may be provided"))
+            end
             nchunks = !isnothing(nchunks) ? nchunks :
                       !isnothing(ntasks) ? ntasks : -1
             chunksize = isnothing(chunksize) ? -1 : chunksize
@@ -190,6 +193,9 @@ function StaticScheduler(;
             nchunks = nthreads(:default)
             chunksize = -1
         else
+            if !isnothing(nchunks) && !isnothing(ntasks)
+                throw(ArgumentError("nchunks and ntasks are aliases and only one may be provided"))
+            end
             nchunks = !isnothing(nchunks) ? nchunks :
                       !isnothing(ntasks) ? ntasks : -1
             chunksize = isnothing(chunksize) ? -1 : chunksize

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -327,10 +327,10 @@ end;
 
     # scheduler isa Symbol
     for s in (:dynamic, :static, :serial, :greedy)
-        @test tmapreduce(sin, +, 1:100_000; scheduler=s) ≈ res_tmr
+        @test tmapreduce(sin, +, 1:10000; scheduler=s, init=0.0) ≈ res_tmr
     end
     for s in (:dynamic, :static, :greedy)
-        @test tmapreduce(sin, +, 1:100_000; ntasks=2, scheduler=s) ≈ res_tmr
+        @test tmapreduce(sin, +, 1:10000; ntasks=2, scheduler=s, init=0.0) ≈ res_tmr
     end
     for s in (:dynamic, :static)
         @test tmapreduce(sin, +, 1:10000; chunksize=2, scheduler=s) ≈ res_tmr

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -336,6 +336,8 @@ end;
         @test tmapreduce(sin, +, 1:10000; chunksize=2, scheduler=s) ≈ res_tmr
         @test tmapreduce(sin, +, 1:10000; chunking=false, scheduler=s) ≈ res_tmr
         @test tmapreduce(sin, +, 1:10000; nchunks=3, scheduler=s) ≈ res_tmr
+        @test tmapreduce(sin, +, 1:10000; ntasks=3, scheduler=s) ≈ res_tmr
+        @test_throws ArgumentError tmapreduce(sin, +, 1:10000; ntasks=3, nchunks=2, scheduler=s) ≈ res_tmr
     end
 end;
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -132,14 +132,14 @@ end;
             init=0.0
         end
         i
-    end) == 55.0
+    end) === 55.0
     @test @tasks(for i in 1:10
         @set begin
             reducer=(+)
             init=0.0*im
         end
         i
-    end) == (55.0 + 0.0im)
+    end) === (55.0 + 0.0im)
 
     # top-level "kwargs"
     @test @tasks(for i in 1:3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,7 +61,7 @@ sets_to_test = [(~ = isapprox, f = sin ∘ *, op = +,
             end
         end
     end
-end
+end;
 
 @testset "ChunkSplitters.Chunk" begin
     x = rand(100)
@@ -76,7 +76,7 @@ end
             @test isnothing(tforeach(x -> sin.(x), chnks; scheduler))
         end
     end
-end
+end;
 
 @testset "macro API" begin
     # basic
@@ -195,7 +195,7 @@ end
         @set reducer=+
         C.x
     end) == 10*var
-end
+end;
 
 @testset "WithTaskLocals" begin
     let x = TaskLocalValue{Base.RefValue{Int}}(() -> Ref{Int}(0)), y = TaskLocalValue{Base.RefValue{Int}}(() -> Ref{Int}(0))
@@ -234,7 +234,7 @@ end
         @test @fetch(h()) == (4, 4)
         @test @fetch(h()) == (5, 5)
     end
-end
+end;
 
 @testset "chunking mode + chunksize option" begin
     for sched in (DynamicScheduler, StaticScheduler)
@@ -262,6 +262,6 @@ end
             @test treduce(+, 1:10; scheduler) ≈ reduce(+, 1:10)
         end
     end
-end
+end;
 
 # Todo way more testing, and easier tests to deal with

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -327,10 +327,10 @@ end;
 
     # scheduler isa Symbol
     for s in (:dynamic, :static, :serial, :greedy)
-        @test tmapreduce(sin, +, 1:10000; scheduler=s) ≈ res_tmr
+        @test tmapreduce(sin, +, 1:100_000; scheduler=s) ≈ res_tmr
     end
     for s in (:dynamic, :static, :greedy)
-        @test tmapreduce(sin, +, 1:10000; ntasks=2, scheduler=s) ≈ res_tmr
+        @test tmapreduce(sin, +, 1:100_000; ntasks=2, scheduler=s) ≈ res_tmr
     end
     for s in (:dynamic, :static)
         @test tmapreduce(sin, +, 1:10000; chunksize=2, scheduler=s) ≈ res_tmr

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,6 +141,42 @@ end;
         i
     end) == (55.0 + 0.0im)
 
+    # top-level "kwargs"
+    @test @tasks(for i in 1:3
+        @set scheduler=:static
+        @set ntasks=1
+        i
+    end) |> isnothing
+    @test @tasks(for i in 1:3
+        @set scheduler=:static
+        @set nchunks=2
+        i
+    end) |> isnothing
+    @test @tasks(for i in 1:3
+        @set scheduler=:dynamic
+        @set chunksize=2
+        i
+    end) |> isnothing
+    @test @tasks(for i in 1:3
+        @set scheduler=:dynamic
+        @set chunking=false
+        i
+    end) |> isnothing
+    @test_throws ArgumentError @tasks(for i in 1:3
+        @set scheduler=DynamicScheduler()
+        @set chunking=false
+        i
+    end)
+    @test_throws MethodError @tasks(for i in 1:3
+        @set scheduler=:serial
+        @set chunking=false
+        i
+    end)
+    @test_throws MethodError @tasks(for i in 1:3
+        @set scheduler=:dynamic
+        @set asd=123
+        i
+    end)
 
     # TaskLocalValue
     ntd = 2*Threads.nthreads()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,14 +211,22 @@ end;
         @set reducer = (+)
         sum(C * x)
     end)() == 1800
-    
+
     # hygiene / escaping
     var = 3
     sched = StaticScheduler()
+    sched_sym = :static
     data = rand(10)
     red = (a,b) -> a+b
+    n = 2
     @test @tasks(for d in data
         @set scheduler=sched
+        @set reducer=red
+        var * d
+    end) ≈ var * sum(data)
+    @test @tasks(for d in data
+        @set scheduler=sched_sym
+        @set ntasks=n
         @set reducer=red
         var * d
     end) ≈ var * sum(data)


### PR DESCRIPTION
Terminology: By "top-level" keyword arguments I refer to keyword arguments that are directly provided to the parallel function API, e.g to `tmapreduce`, `tmap`, etc. (in contrast to those provided to a `Scheduler` constructor).

**Principle:**
If `scheduler isa Symbol`, then (most) "top-level" keyword arguments are forwarded to the constructor of the `Scheduler` that corresponds to the symbol (if any). If `scheduler isa Scheduler`, to avoid ambiguity, we error if a scheduler option is provided as a "top-level" keyword argument.

**Examples** (see docstrings and `runtests.jl` for more):

```julia
julia> tmapreduce(sin, +, 1:100; scheduler=:static)
-0.12717101366042027

julia> tmapreduce(sin, +, 1:100; ntasks=2)
-0.12717101366041983

julia> tmapreduce(sin, +, 1:100; chunksize=10, scheduler=:static)
-0.12717101366042027

julia> tmapreduce(sin, +, 1:100; chunksize=10, scheduler=StaticScheduler())
ERROR: ArgumentError: Providing an explicit scheduler as well as direct keyword arguments (e.g. chunksize) is currently not supported.
[...]

julia> @tasks for i in 1:100
           @set ntasks=4*nthreads()
           # non-uniform work...
       end

julia> @tasks for i in 1:100
           @set begin
               scheduler=:static
               nchunks=10
           end
           # work ....
       end
```

**More:**
* `StaticScheduler` and `DynamicScheduler` now can also take a `ntasks` keyword argument which is just an alias for `nchunks`.
* `DynamicScheduler` now defaults to `ntasks=nthreads()` (again).

Besides implementing these features, I found and fixed some minor code, docstring, and testing bugs.

Closes #76.