### PR TITLE
Attempt to fix #82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Version 0.5.0
 - ![Breaking][badge-breaking] `DynamicScheduler` and `StaticScheduler` don't support `nchunks=0` or `chunksize=0` any longer. Instead, chunking can now be turned off via an explicit new keyword argument `chunking=false`.
 - ![BREAKING][badge-breaking] Within a `@tasks` block, task-local values must from now on be defined via `@local` instead of `@init` (renamed).
 - ![BREAKING][badge-breaking] The (already deprecated) `SpawnAllScheduler` has been dropped.
+- ![Bugfix][badge-bugfix] When using the `GreedyScheduler` in combination with `tmapreduce` (or functions that build upon it) there could be non-deterministic errors in some cases (small input collection, not much work per element, see [#82](https://github.com/JuliaFolds2/OhMyThreads.jl/issues/82)). These cases should be fixed now.
 
 Version 0.4.6
 -------------

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -15,8 +15,6 @@ using BangBang: append!!
 
 using ChunkSplitters: ChunkSplitters
 
-using StableTasks: StableTasks
-
 include("macro_impl.jl")
 
 function auto_disable_chunking_warning()


### PR DESCRIPTION
Closes #82

I use `try`/`catch` to make the tasks that don't get any elements from the channel return `nothing` gracefully. Afterwards, I filter out these results before performing the final reduction.

**Disadvantages:**
* We potentially ignore `MethodError`s cause by user input (`f`, `op).
* `results = fetch.(tasks)` allocates