### PR TITLE
`SimpleBarrier` and `@barrier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 0.5.1
 -------------
 - ![Feature][badge-feature] Within a parallel `@tasks` block one can now mark a region with `@one_by_one`. This region will be run by one task at a time ("critical region").
 - ![Feature][badge-feature] Within a `@tasks` block one can now mark a region as with `@only_one`. This region will be run by a single parallel task only (other tasks will skip over it).
+- ![Experimental][badge-experimental] Added tentative support for `@barrier` in `@tasks` blocks. See `?OhMyThreads.Tools.@barrier` for more information. Note that this feature is experimental and **not** part of the public API (i.e. doesn't fall under SemVer).
 
 Version 0.5.0
 -------------
@@ -97,6 +98,7 @@ Version 0.2.0
 [badge-breaking]: https://img.shields.io/badge/BREAKING-red.svg
 [badge-deprecation]: https://img.shields.io/badge/Deprecation-orange.svg
 [badge-feature]: https://img.shields.io/badge/Feature-green.svg
+[badge-experimental]: https://img.shields.io/badge/Experimental-yellow.svg
 [badge-enhancement]: https://img.shields.io/badge/Enhancement-blue.svg
 [badge-bugfix]: https://img.shields.io/badge/Bugfix-purple.svg
 [badge-fix]: https://img.shields.io/badge/Fix-purple.svg

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -82,4 +82,52 @@ function reset!(s::OnlyOneRegion)
     nothing
 end
 
+"""
+SimpleBarrier(n::Integer)
+
+Simple reusable barrier for `n` parallel tasks.
+
+Given `b = SimpleBarrier(n)` and `n` parallel tasks, each task that calls
+`wait(b)` will block until the other `n-1` tasks have called `wait(b)` as well.
+
+## Example
+```
+n = nthreads()
+barrier = SimpleBarrier(n)
+@sync for i in 1:n
+    @spawn begin
+        println("A")
+        wait(barrier) # synchronize all tasks
+        println("B")
+        wait(barrier) # synchronize all tasks (reusable)
+        println("C")
+    end
+end
+```
+"""
+mutable struct SimpleBarrier
+    const n::Int64
+    const c::Threads.Condition
+    cnt::Int64
+
+    function SimpleBarrier(n::Integer)
+        new(n, Threads.Condition(), 0)
+    end
+end
+
+function Base.wait(b::SimpleBarrier)
+    lock(b.c)
+    try
+        b.cnt += 1
+        if b.cnt == b.n
+            b.cnt = 0
+            notify(b.c)
+        else
+            wait(b.c)
+        end
+    finally
+        unlock(b.c)
+    end
+end
+
 end # Tools

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -130,4 +130,44 @@ function Base.wait(b::SimpleBarrier)
     end
 end
 
+"""
+    @barrier
+    @barrier(ntasks)
+
+This can be used inside a `@tasks for ... end` to synchronize `ntasks` parallel tasks.
+Specifically, a task can only pass the `@barrier` if `ntask-1` other tasks have reached it
+as well. If `ntasks` is not given explicitly it is determined from `@set ntasks=...`, which
+is mandatory in this case.
+
+**WARNING:** It is the responsibility of the user to ensure that the number of iterations
+is a multiple of `ntasks`. Otherwise, for the last few iterations (remainder) not enough
+tasks will reach the `@barrier` leading to a **deadlock**.
+
+## Example
+
+```julia
+using OhMyThreads: @tasks
+
+@tasks for i in 1:20
+    @set ntasks = 20
+
+    println(i, ": before")
+    @barrier
+    println(i, ": after")
+end
+
+# wrong - deadlock!
+@tasks for i in 1:22 # ntasks % niterations != 0
+    @set ntasks = 20
+
+    println(i, ": before")
+    @barrier
+    println(i, ": after")
+end
+```
+"""
+macro barrier(args...)
+    error("The @barrier macro may only be used inside of a @tasks block.")
+end
+
 end # Tools

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -478,6 +478,25 @@ end
 end;
 
 @testset "@barrier" begin
+    @test (@tasks for i in 1:20
+        @set ntasks = 20
+        @barrier
+    end) |> isnothing
+
+    @test try
+        @macroexpand @tasks for i in 1:20
+            @barrier
+        end
+        false
+    catch
+        true
+    end
+
+    @test (@tasks for i in 1:20
+        @set ntasks = 20
+        @barrier(20)
+    end) |> isnothing
+
     @test try
         x = Threads.Atomic{Int64}(0)
         y = Threads.Atomic{Int64}(0)


### PR DESCRIPTION
Preliminary attempt at https://github.com/JuliaFolds2/OhMyThreads.jl/issues/74.

Adds a `SimpleBarrier` to `OhMyThreads.Tools` and introduces `@barrier` (to be used within `@tasks`). All of this is internal/experimental and not officially made public API. The primary reason is that one can rather easily hit deadlocks. Let me quote the docstring of `@barrier`:

```julia
  @barrier
  @barrier(ntasks)


  This can be used inside a @tasks for ... end to synchronize ntasks parallel tasks.
  Specifically, a task can only pass the @barrier if ntask-1 other tasks have reached
  it as well. If ntasks is not given explicitly it is determined from @set ntasks=...,
  which is mandatory in this case.

  WARNING: It is the responsibility of the user to ensure that the number of
  iterations is a multiple of ntasks. Otherwise, for the last few iterations
  (remainder) not enough tasks will reach the @barrier leading to a deadlock.

  Example
  =======

  using OhMyThreads: @tasks
  
  @tasks for i in 1:20
      @set ntasks = 20
  
      println(i, ": before")
      @barrier
      println(i, ": after")
  end
  
  # wrong - deadlock!
  @tasks for i in 1:22 # ntasks % niterations != 0
      @set ntasks = 20
  
      println(i, ": before")
      @barrier
      println(i, ": after")
  end
```