### PR TITLE
relax BangBang compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 0.5.1
 - ![Feature][badge-feature] Within a parallel `@tasks` block one can now mark a region with `@one_by_one`. This region will be run by one task at a time ("critical region").
 - ![Feature][badge-feature] Within a `@tasks` block one can now mark a region as with `@only_one`. This region will be run by a single parallel task only (other tasks will skip over it).
 - ![Experimental][badge-experimental] Added tentative support for `@barrier` in `@tasks` blocks. See `?OhMyThreads.Tools.@barrier` for more information. Note that this feature is experimental and **not** part of the public API (i.e. doesn't fall under SemVer).
+- ![Info][badge-info] Compat bounds for [BangBang.jl](https://github.com/JuliaFolds2/BangBang.jl) have been relaxed to include v0.3.40
 
 Version 0.5.0
 -------------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OhMyThreads"
 uuid = "67456a42-1dca-4109-a031-0a68de7e3ad5"
 authors = ["Carsten Bauer <mail@carstenbauer.eu>", "Mason Protter <mason.protter@icloud.com>"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ TaskLocalValues = "ed4db957-447d-4319-bfb6-7fa9ae7ecf34"
 
 [compat]
 Aqua = "0.8"
-BangBang = "0.4"
+BangBang = "0.3.40, 0.4"
 ChunkSplitters = "2.4"
 StableTasks = "0.1.5"
 TaskLocalValues = "0.1"


### PR DESCRIPTION
While https://github.com/JuliaFolds2/Transducers.jl/issues/31 and https://github.com/JuliaML/MLUtils.jl/issues/175 are sorted out, this PR relaxes BangBang compact to v0.3 so that OhMyThreads becomes compatible with many packages in the ML ecosystem.

I tested locally on BangBang v0.3.40 and all tests pass.
