### PR TITLE
Handle empty input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 OhMyThreads.jl Changelog
 =========================
 
+Version 0.5.2
+-------------
+- ![Enhancement][badge-enhancement] For empty input (e.g. `Float64[]` or `11:10`) behavior is now aligned with the serial functions in `Base`.
+
 Version 0.5.1
 -------------
 - ![Feature][badge-feature] Within a parallel `@tasks` block one can now mark a region with `@one_by_one`. This region will be run by one task at a time ("critical region").

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -364,6 +364,11 @@ end;
 end;
 
 @testset "empty collections" begin
+    @static if VERSION < v"1.11.0-"
+        err = MethodError
+    else
+        err = ArgumentError
+    end
     for empty_coll in (11:9, Float64[])
         for f in (sin, x -> im * x, identity)
             for op in (+, *, min)
@@ -377,7 +382,7 @@ end;
                 if op != min
                     @test treduce(op, empty_coll) == reduce(op, empty_coll)
                 else
-                    @test_throws MethodError treduce(op, empty_coll)
+                    @test_throws err treduce(op, empty_coll)
                 end
                 # map
                 @test tmap(f, empty_coll) == map(f, empty_coll)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -367,11 +367,22 @@ end;
     for empty_coll in (11:9, Float64[])
         for f in (sin, x -> im * x, identity)
             for op in (+, *, min)
-                @test_throws ArgumentError tmapreduce(f, op, empty_coll)
+                # mapreduce
                 for init in (0.0, 0, 0.0 * im, 0.0f0)
                     @test tmapreduce(f, op, empty_coll; init) == init
                 end
+                # foreach
                 @test tforeach(f, empty_coll) |> isnothing
+                # reduce
+                if op != min
+                    @test treduce(op, empty_coll) == reduce(op, empty_coll)
+                else
+                    @test_throws MethodError treduce(op, empty_coll)
+                end
+                # map
+                @test tmap(f, empty_coll) == map(f, empty_coll)
+                # collect
+                @test tcollect(empty_coll) == collect(empty_coll)
             end
         end
     end


### PR DESCRIPTION
Extension of #88.
Closes #87.

With this PR, we now explicitly fall back to the serial `Base` functions if the input `isempty`.

Shouldn't be breaking because we pretty much always error'ed before.