### PR TITLE
Support for `enumerate(chunks(...))`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 OhMyThreads.jl Changelog
 =========================
 
+Version 0.6.2
+-------------
+- ![Enhancement][badge-enhancement] Added API support for `enumerate(chunks(...))`. Best used in combination with `chunking=false`.
+
+Version 0.6.1
+-------------
+
 Version 0.6.0
 -------------
 - ![BREAKING][badge-breaking] Drop support for Julia < 1.10.

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -320,7 +320,7 @@ function tmap(f, ::Type{T}, A::AbstractArray, _Arrs::AbstractArray...; kwargs...
 end
 
 function tmap(f,
-        A::Union{AbstractArray, ChunkSplitters.Chunk},
+        A::Union{AbstractArray, ChunkSplitters.Chunk, ChunkSplitters.Enumerate},
         _Arrs::AbstractArray...;
         scheduler::MaybeScheduler = NotGiven(),
         kwargs...)
@@ -333,7 +333,8 @@ function tmap(f,
        _scheduler.split != :batch
         error("Only `split == :batch` is supported because the parallel operation isn't commutative. (Scheduler: $_scheduler)")
     end
-    if A isa ChunkSplitters.Chunk && chunking_enabled(_scheduler)
+    if (A isa ChunkSplitters.Chunk || A isa ChunkSplitters.Enumerate) &&
+       chunking_enabled(_scheduler)
         auto_disable_chunking_warning()
         if _scheduler isa DynamicScheduler
             _scheduler = DynamicScheduler(;
@@ -377,7 +378,7 @@ end
 # w/o chunking (DynamicScheduler{NoChunking}): ChunkSplitters.Chunk
 function _tmap(scheduler::DynamicScheduler{NoChunking},
         f,
-        A::ChunkSplitters.Chunk,
+        A::Union{ChunkSplitters.Chunk, ChunkSplitters.Enumerate},
         _Arrs::AbstractArray...)
     (; threadpool) = scheduler
     tasks = map(A) do idcs

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -105,11 +105,11 @@ end
 # DynamicScheduler: ChunkSplitters.Chunk
 function _tmapreduce(f,
         op,
-        Arrs::Tuple{ChunkSplitters.Chunk{T}}, # we don't support multiple chunks for now
+        Arrs::Union{Tuple{ChunkSplitters.Chunk{T}}, Tuple{ChunkSplitters.Enumerate{T}}},
         ::Type{OutputType},
         scheduler::DynamicScheduler,
         mapreduce_kwargs)::OutputType where {OutputType, T}
-    (; nchunks, split, threadpool) = scheduler
+    (; threadpool) = scheduler
     chunking_enabled(scheduler) && auto_disable_chunking_warning()
     tasks = map(only(Arrs)) do idcs
         @spawn threadpool promise_task_local(f)(idcs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,13 +86,13 @@ end;
 
     # enumerate(chunks)
     data = 1:100
-    @test tmapreduce(+, enumerate(chunks(data; n=5)); chunking=false) do (i, idcs)
+    @test tmapreduce(+, enumerate(OhMyThreads.chunks(data; n=5)); chunking=false) do (i, idcs)
         [i, sum(@view(data[idcs]))]
     end == [sum(1:5), sum(data)]
-    @test tmapreduce(+, enumerate(chunks(data; size=5)); chunking=false) do (i, idcs)
+    @test tmapreduce(+, enumerate(OhMyThreads.chunks(data; size=5)); chunking=false) do (i, idcs)
         [i, sum(@view(data[idcs]))]
     end == [sum(1:20), sum(data)]
-    @test tmap(enumerate(chunks(data; n=5)); chunking=false) do (i, idcs)
+    @test tmap(enumerate(OhMyThreads.chunks(data; n=5)); chunking=false) do (i, idcs)
         [i, idcs]
     end == [[1, 1:20], [2, 21:40], [3, 41:60], [4, 61:80], [5, 81:100]]
 end;
@@ -261,16 +261,16 @@ end;
 
     # enumerate(chunks)
     data = collect(1:100)
-    @test @tasks(for (i, idcs) in enumerate(chunks(data; n=5))
+    @test @tasks(for (i, idcs) in enumerate(OhMyThreads.chunks(data; n=5))
         @set reducer = +
         @set chunking = false
         [i, sum(@view(data[idcs]))]
     end) == [sum(1:5), sum(data)]
-    @test @tasks(for (i, idcs) in enumerate(chunks(data; size=5))
+    @test @tasks(for (i, idcs) in enumerate(OhMyThreads.chunks(data; size=5))
         @set reducer = +
         [i, sum(@view(data[idcs]))]
     end) == [sum(1:20), sum(data)]
-    @test @tasks(for (i, idcs) in enumerate(chunks(1:100; n=5))
+    @test @tasks(for (i, idcs) in enumerate(OhMyThreads.chunks(1:100; n=5))
         @set chunking=false
         @set collect=true
         [i, idcs]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,6 +92,9 @@ end;
     @test tmapreduce(+, enumerate(chunks(data; size=5)); chunking=false) do (i, idcs)
         [i, sum(@view(data[idcs]))]
     end == [sum(1:20), sum(data)]
+    @test tmap(enumerate(chunks(data; n=5)); chunking=false) do (i, idcs)
+        [i, idcs]
+    end == [[1, 1:20], [2, 21:40], [3, 41:60], [4, 61:80], [5, 81:100]]
 end;
 
 @testset "macro API" begin
@@ -267,6 +270,11 @@ end;
         @set reducer = +
         [i, sum(@view(data[idcs]))]
     end) == [sum(1:20), sum(data)]
+    @test @tasks(for (i, idcs) in enumerate(chunks(1:100; n=5))
+        @set chunking=false
+        @set collect=true
+        [i, idcs]
+    end) == [[1, 1:20], [2, 21:40], [3, 41:60], [4, 61:80], [5, 81:100]]
 end;
 
 @testset "WithTaskLocals" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,6 +83,15 @@ end;
             @test isnothing(tforeach(x -> sin.(x), chnks; scheduler))
         end
     end
+
+    # enumerate(chunks)
+    data = 1:100
+    @test tmapreduce(+, enumerate(chunks(data; n=5)); chunking=false) do (i, idcs)
+        [i, sum(@view(data[idcs]))]
+    end == [sum(1:5), sum(data)]
+    @test tmapreduce(+, enumerate(chunks(data; size=5)); chunking=false) do (i, idcs)
+        [i, sum(@view(data[idcs]))]
+    end == [sum(1:20), sum(data)]
 end;
 
 @testset "macro API" begin
@@ -246,6 +255,18 @@ end;
         @set reducer = +
         C.x
     end) == 10 * var
+
+    # enumerate(chunks)
+    data = collect(1:100)
+    @test @tasks(for (i, idcs) in enumerate(chunks(data; n=5))
+        @set reducer = +
+        @set chunking = false
+        [i, sum(@view(data[idcs]))]
+    end) == [sum(1:5), sum(data)]
+    @test @tasks(for (i, idcs) in enumerate(chunks(data; size=5))
+        @set reducer = +
+        [i, sum(@view(data[idcs]))]
+    end) == [sum(1:20), sum(data)]
 end;
 
 @testset "WithTaskLocals" begin


### PR DESCRIPTION
With this PR:

```julia
julia> @tasks for (c,v) in enumerate(chunks(rand(10); n=2))
           @set chunking=false
           @show c
       end
c = 2
c = 1

julia> @tasks for (c,v) in enumerate(chunks(rand(10); n=2))
           @set chunking=false
           @set reducer=+
           c
       end
3

julia> @tasks for (c,v) in enumerate(chunks(rand(10); n=2))
           @set chunking=false
           @set collect=true
           c
       end
2-element Vector{Int64}:
 1
 2
```

Before this PR:

```julia
julia> @tasks for (c,v) in enumerate(chunks(rand(10); n=2))
           @set chunking=false
           @show c
       end
ERROR: MethodError: no method matching keys(::ChunkSplitters.Enumerate{ChunkSplitters.Chunk{…}})

Closest candidates are:
  keys(::Pkg.Registry.RegistryInstance)
   @ Pkg ~/.julia/juliaup/julia-1.10.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/Pkg/src/Registry/registry_instance.jl:447
  keys(::LibGit2.GitTree)
   @ Revise ~/.julia/packages/Revise/uvGMC/src/git.jl:52
  keys(::Core.SimpleVector)
   @ Base essentials.jl:781
  ...

Stacktrace:
 [1] eachindex(itrs::ChunkSplitters.Enumerate{ChunkSplitters.Chunk{…}})
   @ Base ./abstractarray.jl:318
 [2] _tmapreduce(f::Function, op::Function, Arrs::Tuple{…}, ::Type{…}, scheduler::DynamicScheduler{…}, mapreduce_kwargs::@NamedTuple{…})
   @ OhMyThreads.Implementation ~/repos/OhMyThreads.jl/src/implementation.jl:97
 [3] #tmapreduce#21
   @ ~/repos/OhMyThreads.jl/src/implementation.jl:67 [inlined]
 [4] tmapreduce
   @ ~/repos/OhMyThreads.jl/src/implementation.jl:55 [inlined]
 [5] tforeach(f::Function, A::ChunkSplitters.Enumerate{ChunkSplitters.Chunk{…}}; kwargs::@Kwargs{chunking::Bool})
   @ OhMyThreads.Implementation ~/repos/OhMyThreads.jl/src/implementation.jl:293
 [6] macro expansion
   @ ~/repos/OhMyThreads.jl/src/macro_impl.jl:107 [inlined]
 [7] top-level scope
   @ REPL[4]:1
Some type information was truncated. Use `show(err)` to see complete types.
```