### PR TITLE
Add concurrency safe iterator wrapper ChannelLike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version 0.7.0
 - ![BREAKING][badge-breaking] If you provide a `chunks` or `index_chunks` as input we now disable the internal chunking without a warning. Previously, we did show a warning unless you had set `chunking=false`. In contrast, we now throw an error when you set any incompatible chunking related keyword arguments.
 - ![Deprecation][badge-deprecation] The `split` options `:batch` and `:scatter` are now deprecated (they still work but will be dropped at some point). Use `:consecutive` and `:roundrobin`, respectively, instead.
 - ![Enhancement][badge-enhancement] The `split` keyword argument can now also be a `<: OhMyThreads.Split`. Compared to providing a `Symbol`, the former can potentially give better performance. For example, you can replace `:consecutive` by `OhMyThreads.Consecutive()` and `:roundrobin` by `OhMyThreads.RoundRobin()`.
+- ![Feature][badge-feature] `ChannelLike` is a new public (but not exported) type. `ChannelLike(itr)` provide a way to iterate over `itr` in a concurrency safe manner similar to `Channel`. See the docstring for more details. ([#121][gh-pr-121])
+- ![Enhancement][badge-enhancement] `ChannelLike` is used internally for the `GreedyScheduler` when `chunking=true`. This improves performance overall but it is especially noticeable when the number of chunks is large. ([#121][gh-pr-121])
 
 Version 0.6.2
 -------------
@@ -136,3 +138,4 @@ Version 0.2.0
 [gh-issue-25]: https://github.com/JuliaFolds2/OhMyThreads.jl/issues/25
 
 [gh-pr-5]: https://github.com/JuliaFolds2/OhMyThreads.jl/pull/5
+[gh-pr-121]: https://github.com/JuliaFolds2/OhMyThreads.jl/pull/121

--- a/docs/src/literate/tls/tls.jl
+++ b/docs/src/literate/tls/tls.jl
@@ -382,6 +382,13 @@ sort(res_nu) ≈ sort(res_channel_flipped)
 @btime matmulsums_perthread_channel_flipped($As_nu, $Bs_nu; ntasks = 2 * nthreads());
 @btime matmulsums_perthread_channel_flipped($As_nu, $Bs_nu; ntasks = 10 * nthreads());
 
+# In addition, OhMyThreads provides an iterator-wrapper type
+# [`OhMyThreads.ChannelLike`](@ref) which can be used in place of a `Channel`. If
+# the number of elements is large this can be more efficient since there is no
+# need to copy the elements into the `Channel`. Concretely, in the example above,
+# we could replace `Channel() do .. end` with
+# `OhMyThreads.ChannelLike(1:length(As))`.
+
 # ## Bumper.jl (only for the brave)
 #
 # If you are bold and want to cut down temporary allocations even more you can

--- a/docs/src/literate/tls/tls.md
+++ b/docs/src/literate/tls/tls.md
@@ -490,6 +490,13 @@ Quick benchmark:
 
 ````
 
+In addition, OhMyThreads provides an iterator-wrapper type
+[`OhMyThreads.ChannelLike`](@ref) which can be used in place of a `Channel`. If
+the number of elements is large this can be more efficient since there is no
+need to copy the elements into the `Channel`. Concretely, in the example above,
+we could replace `Channel() do .. end` with
+`OhMyThreads.ChannelLike(1:length(As))`.
+
 ## Bumper.jl (only for the brave)
 
 If you are bold and want to cut down temporary allocations even more you can

--- a/docs/src/refs/api.md
+++ b/docs/src/refs/api.md
@@ -61,4 +61,5 @@ SerialScheduler
 ```@docs
 OhMyThreads.WithTaskLocals
 OhMyThreads.promise_task_local
+OhMyThreads.ChannelLike
 ```

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -233,8 +233,9 @@ end
 """
     GreedyScheduler (aka :greedy)
 
-A greedy dynamic scheduler. The elements of the collection are first put into a `Channel`
-and then dynamic, non-sticky tasks are spawned to process the channel content in parallel.
+A greedy dynamic scheduler. The elements are put into a shared workqueue and dynamic,
+non-sticky, tasks are spawned to process the elements of the queue with each task taking a new
+element from the queue as soon as the previous one is done.
 
 Note that elements are processed in a non-deterministic order, and thus a potential reducing
 function **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in
@@ -249,10 +250,10 @@ some additional overhead.
     * Determines the number of parallel tasks to be spawned.
     * Setting `ntasks < nthreads()` is an effective way to use only a subset of the available threads.
 - `chunking::Bool` (default `false`):
-    * Controls whether input elements are grouped into chunks (`true`) or not (`false`) before put into the channel. This can improve the performance especially if there are many iterations each of which are computationally cheap.
+    * Controls whether input elements are grouped into chunks (`true`) or not (`false`) before put into the shared workqueue. This can improve the performance especially if there are many iterations each of which are computationally cheap.
     * If `nchunks` or `chunksize` are explicitly specified, `chunking` will be automatically set to `true`.
 - `nchunks::Integer` (default `10 * nthreads()`):
-    * Determines the number of chunks (that will eventually be put into the channel).
+    * Determines the number of chunks (that will eventually be put into the shared workqueue).
     * Increasing `nchunks` can help with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)). For `nchunks <= nthreads()` there are not enough chunks for any load balancing.
 - `chunksize::Integer` (default not set)
     * Specifies the desired chunk size (instead of the number of chunks).


### PR DESCRIPTION
Just to show that the idea from https://github.com/JuliaFolds2/ChunkSplitters.jl/issues/49 can be used to improve the (chunked) GreedyScheduler.
The advantages are that the iterator doesn't have to be copied into a Channel, and that the AtomicChunk-thingy is more efficient (but not as general, of course) than a Channel. See some benchmarks in the test.jl file.