### PR TITLE
rewrite schedulers

### DIFF
--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -7,7 +7,7 @@ using OhMyThreads: Scheduler,
                    DynamicScheduler, StaticScheduler, GreedyScheduler,
                    SerialScheduler
 using OhMyThreads.Schedulers: chunking_enabled,
-                              nchunks, chunksize, chunksplit,
+                              nchunks, chunksize, chunksplit, has_chunksplit,
                               chunking_mode, ChunkingMode, NoChunking,
                               FixedSize, FixedCount, scheduler_from_symbol, NotGiven,
                               isgiven
@@ -345,7 +345,7 @@ function tmap(f,
     if _scheduler isa GreedyScheduler
         error("Greedy scheduler isn't supported with `tmap` unless you provide an `OutputElementType` argument, since the greedy schedule requires a commutative reducing operator.")
     end
-    if chunking_enabled(_scheduler) && hasfield(typeof(_scheduler), :split) &&
+    if chunking_enabled(_scheduler) && has_chunksplit(_scheduler) &&
        chunksplit(_scheduler) != Consecutive()
         error("Only `split == Consecutive()` is supported because the parallel operation isn't commutative. (Scheduler: $_scheduler)")
     end

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -7,6 +7,7 @@ using OhMyThreads: Scheduler,
                    DynamicScheduler, StaticScheduler, GreedyScheduler,
                    SerialScheduler
 using OhMyThreads.Schedulers: chunking_enabled,
+                              nchunks, chunksize, chunksplit,
                               chunking_mode, ChunkingMode, NoChunking,
                               FixedSize, FixedCount, scheduler_from_symbol, NotGiven,
                               isgiven
@@ -25,13 +26,13 @@ function _index_chunks(sched, arg)
     @assert C != NoChunking
     if C == FixedCount
         index_chunks(arg;
-            n = sched.nchunks,
-            split = sched.split)::IndexChunks{
+            n = nchunks(sched),
+            split = chunksplit(sched))::IndexChunks{
             typeof(arg), ChunkSplitters.Internals.FixedCount}
     elseif C == FixedSize
         index_chunks(arg;
-            size = sched.chunksize,
-            split = sched.split)::IndexChunks{
+            size = chunksize(sched),
+            split = chunksplit(sched))::IndexChunks{
             typeof(arg), ChunkSplitters.Internals.FixedSize}
     end
 end
@@ -50,9 +51,9 @@ end
 function _check_chunks_incompatible_kwargs(; kwargs...)
     ks = keys(kwargs)
     if :ntasks in ks || :nchunks in ks || :chunksize in ks || :split in ks
-        error("You've provided `chunks` or `index_chunks` as input and, at the same time, "*
-              "chunking related keyword arguments (e.g. `ntasks`, `chunksize`, or `split`). "*
-              "This isn't supported. "*
+        error("You've provided `chunks` or `index_chunks` as input and, at the same time, " *
+              "chunking related keyword arguments (e.g. `ntasks`, `chunksize`, or `split`). " *
+              "This isn't supported. " *
               "Set the chunking options directly in the `chunks` or `index_chunks` call or drop the latter.")
     end
     if :chunking in ks
@@ -345,7 +346,7 @@ function tmap(f,
         error("Greedy scheduler isn't supported with `tmap` unless you provide an `OutputElementType` argument, since the greedy schedule requires a commutative reducing operator.")
     end
     if chunking_enabled(_scheduler) && hasfield(typeof(_scheduler), :split) &&
-       _scheduler.split != Consecutive()
+       chunksplit(_scheduler) != Consecutive()
         error("Only `split == Consecutive()` is supported because the parallel operation isn't commutative. (Scheduler: $_scheduler)")
     end
     if (A isa AbstractChunks || A isa ChunkSplitters.Internals.Enumerate)

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -111,9 +111,6 @@ function ChunkingArgs(
     # argument names in error messages are those of the scheduler constructor instead
     # of ChunkingArgs because the user should not be aware of the ChunkingArgs type
     # (e.g. `nchunks` instead of `n`)
-    if !(has_split(result))
-        throw(ArgumentError("split must be a valid Split type or Symbol"))
-    end
     if !(has_n(result) || has_size(result))
         throw(ArgumentError("Either `nchunks` or `chunksize` must be a positive integer (or chunking=false)."))
     end
@@ -141,9 +138,15 @@ end
 # The first and only the first method must be overloaded for each scheduler
 # that supports chunking.
 chunking_args(::Scheduler) = ChunkingArgs(NoChunking)
+
 nchunks(sched::Scheduler) = chunking_args(sched).n
 chunksize(sched::Scheduler) = chunking_args(sched).size
 chunksplit(sched::Scheduler) = chunking_args(sched).split
+
+has_nchunks(sched::Scheduler) = has_n(chunking_args(sched))
+has_chunksize(sched::Scheduler) = has_size(chunking_args(sched))
+has_chunksplit(sched::Scheduler) = has_split(chunking_args(sched))
+
 chunking_mode(sched::Scheduler) = chunking_mode(chunking_args(sched))
 chunking_enabled(sched::Scheduler) = chunking_enabled(chunking_args(sched))
 _chunkingstr(sched::Scheduler) = _chunkingstr(chunking_args(sched))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -756,7 +756,8 @@ end
          ├ Num. tasks: $nt
          ├ Chunking: fixed count ($(10 * nt)), split :roundrobin
          └ Threadpool: default"""
-
+end
+  
 @testset "Boxing detection and error" begin
     let
         f1() = tmap(1:10) do i

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -410,6 +410,8 @@ end;
             sin, +, 1:10000; ntasks = 3, nchunks = 2, scheduler = s)≈res_tmr
     end
     @test_throws ArgumentError tmapreduce(sin, +, 1:10000; scheduler = :whatever)
+    @test_throws ArgumentError tmapreduce(
+        sin, +, 1:10000; threadpool = :whatever, chunking = false)
 end;
 
 @testset "empty collections" begin


### PR DESCRIPTION
I tried to implement #114 and I quickly got lost in all these if/else branches (surely added bit by bit). I noticed that the problem was that everything was mixed up between what is chunking and what is not. And everything that is chunking is common to each scheduler.

So I rewrote the module to make the difference between the two clear. This is done by encapsulating everything related to chunking into a new internal type `ChunkingArgs`. Then each Scheduler contains only one instance of this type instead of all the chunking arguments.

Otherwise nothing should really change outside the module, except:
- `shed(;chunking=false, split=:whatever)` returned an `ArgumentError`. It's no longer the case. This makes the code simpler and I think it fits better with what the documentation describes: "For chunking=false, the arguments nchunks/ntasks, chunksize, and split are ignored"
- Using `sched.nchunks`, `sched.chunkisze` or `sched.split` no longer works and is replaced by functions of the same name (e.g. `nchunks(sched)`. This is because they are encapsulated into `sched.chunking_args`, so they are no longer direct fields. We could implement a [`Base.getproperty`](https://docs.julialang.org/en/v1/base/base/#Base.getproperty) though, but I don't think it's really necessary.

With these changes, adding chunking arguments or even a new type of Scheduler becomes easier.