### PR TITLE
Detect and throw an error when multithreading with `Box`ed variables

### DIFF
--- a/.github/workflows/downgrade_CI.yml
+++ b/.github/workflows/downgrade_CI.yml
@@ -23,6 +23,6 @@ jobs:
           version: ${{ matrix.version }}
       - uses: cjdoris/julia-downgrade-compat-action@v1
         with:
-          skip: Pkg,TOML
+          skip: Pkg,TOML,Test
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 OhMyThreads.jl Changelog
 =========================
 
+Version 0.8.0
+-------------
+- ![BREAKING][badge-breaking] We now detect and throw errors if an `OhMyThreads` parallel function is passed a closure containing a `Box`ed variable. This behaviour can be disabled with the new `@allow_boxed_captures` macro, and re-enabled with `@disallow_boxed_captures`. ([#141][gh-pr-141])
+
 Version 0.7.0
 -------------
 - ![BREAKING][badge-breaking] We now use ChunkSplitters version 3.0. The function `OhMyThreads.chunks` has been renamed to `OhMyThreads.index_chunks`. The new functions `index_chunks` and `chunks` (different from the old one with the same name!) are now exported. See ChunkSplitters.jl for more information.
@@ -139,3 +143,4 @@ Version 0.2.0
 
 [gh-pr-5]: https://github.com/JuliaFolds2/OhMyThreads.jl/pull/5
 [gh-pr-121]: https://github.com/JuliaFolds2/OhMyThreads.jl/pull/121
+[gh-pr-141]: https://github.com/JuliaFolds2/OhMyThreads.jl/pull/141

--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,12 @@
 name = "OhMyThreads"
 uuid = "67456a42-1dca-4109-a031-0a68de7e3ad5"
 authors = ["Carsten Bauer <mail@carstenbauer.eu>", "Mason Protter <mason.protter@icloud.com>"]
-version = "0.7.0"
+version = "0.8.0"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
 ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"
+ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
 StableTasks = "91464d47-22a1-43fe-8b7f-2d57ee82463f"
 TaskLocalValues = "ed4db957-447d-4319-bfb6-7fa9ae7ecf34"
 

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ BangBang = "0.3.40, 0.4"
 ChunkSplitters = "3"
 StableTasks = "0.1.5"
 TaskLocalValues = "0.1"
+ScopedValues = "1.3"
 Test = "1"
 julia = "1.10"
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,6 +27,7 @@ makedocs(;
             "Trapezoidal Integration" => "literate/integration/integration.md"
         ],
         "Translation Guide" => "translation.md",
+        "Boxed Variables" => "literate/boxing/boxing.md",
         "Thread-Safe Storage" => "literate/tls/tls.md",
         "False Sharing" => "literate/falsesharing/falsesharing.md",
         # "Explanations" => [

--- a/docs/src/literate/boxing/Project.toml
+++ b/docs/src/literate/boxing/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"

--- a/docs/src/literate/boxing/boxing.jl
+++ b/docs/src/literate/boxing/boxing.jl
@@ -1,0 +1,63 @@
+#====================================
+# Boxed Variables
+
+All multithreading in julia is built around the idea of passing around
+and executing functions, but often these functions "enclose" data from
+an outer local scope, making them what's called a "closure".
+
+Julia allows functions which capture variables to re-bind those variables
+to different values, but doing so can cause subtle race conditions in
+multithreaded code.
+
+Consider the following example:
+====================================#
+
+let out = zeros(Int, 10)
+    Threads.@threads for i in 1:10
+        A = i
+        sleep(1/100)
+        out[i] = A
+    end
+    A = 1
+    out
+end
+
+#====================================
+You may have expected that to return `[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]`,
+but the nonsense result is caused by `A` actually being a shared mutable
+container here which all the parallel tasks are accessing and mutating
+in parallel, giving unpredictable results.
+
+OhMyThreads.jl tries to protect users from this surprising behaviour:
+====================================#
+using OhMyThreads
+
+try
+    let
+        ## this throws an error!
+        out = tmap(1:10) do i
+            A = i
+            sleep(1/100)
+            A
+        end
+        A = 1
+        out
+    end
+catch e;
+    println(e.msg) # show that error
+end
+
+#====================================
+If you really desire to bypass this behaviour, you can use the
+`@allow_boxed_captures` macro
+====================================#
+
+@allow_boxed_captures let
+    out = tmap(1:10) do i
+        A = i
+        sleep(1/100)
+        A
+    end
+    A = 1
+    out
+end

--- a/docs/src/literate/boxing/boxing.md
+++ b/docs/src/literate/boxing/boxing.md
@@ -1,0 +1,110 @@
+```@meta
+EditURL = "boxing.jl"
+```
+
+# Boxed Variables
+
+All multithreading in julia is built around the idea of passing around
+and executing functions, but often these functions "enclose" data from
+an outer local scope, making them what's called a "closure".
+
+Julia allows functions which capture variables to re-bind those variables
+to different values, but doing so can cause subtle race conditions in
+multithreaded code.
+
+Consider the following example:
+
+````julia
+let out = zeros(Int, 10)
+    Threads.@threads for i in 1:10
+        A = i
+        sleep(1/100)
+        out[i] = A
+    end
+    A = 1
+    out
+end
+````
+
+````
+10-element Vector{Int64}:
+ 6
+ 2
+ 3
+ 2
+ 3
+ 2
+ 3
+ 2
+ 3
+ 4
+````
+
+You may have expected that to return `[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]`,
+but the nonsense result is caused by `A` actually being a shared mutable
+container here which all the parallel tasks are accessing and mutating
+in parallel, giving unpredictable results.
+
+OhMyThreads.jl tries to protect users from this surprising behaviour:
+
+````julia
+using OhMyThreads
+
+try
+    let
+        # this throws an error!
+        out = tmap(1:10) do i
+            A = i
+            sleep(1/100)
+            A
+        end
+        A = 1
+        out
+    end
+catch e;
+    println(e.msg) # show that error
+end
+````
+
+````
+Attempted to capture and modify outer local variable(s) A, which would be not only slow, but could also cause a race condition. Consider marking these variables as local inside their respective closure, or redesigning your code to avoid the race condition.
+
+If these variables are inside a @one_by_one or @only_one block, consider using a mutable Ref instead of re-binding the variable.
+
+This error can be bypassed with the @allow_boxed_captures macro.
+
+````
+
+If you really desire to bypass this behaviour, you can use the
+`@allow_boxed_captures` macro
+
+````julia
+@allow_boxed_captures let
+    out = tmap(1:10) do i
+        A = i
+        sleep(1/100)
+        A
+    end
+    A = 1
+    out
+end
+````
+
+````
+10-element Vector{Int64}:
+ 7
+ 6
+ 7
+ 6
+ 7
+ 6
+ 7
+ 6
+ 7
+ 7
+````
+
+---
+
+*This page was generated using [Literate.jl](https://github.com/fredrikekre/Literate.jl).*
+

--- a/docs/src/refs/api.md
+++ b/docs/src/refs/api.md
@@ -13,6 +13,8 @@ CollapsedDocStrings = true
 @local
 @only_one
 @one_by_one
+@allow_boxed_captures
+@disallow_boxed_captures
 ```
 
 ### Functions

--- a/src/OhMyThreads.jl
+++ b/src/OhMyThreads.jl
@@ -16,11 +16,7 @@ export chunks, index_chunks
 using TaskLocalValues: TaskLocalValues
 const TaskLocalValue = TaskLocalValues.TaskLocalValue
 
-if isdefined(Base, :ScopedValues)
-    using Base.ScopedValues: ScopedValues, ScopedValue, @with
-else
-    using ScopedValues: ScopedValues, ScopedValue, @with
-end
+using ScopedValues: ScopedValues, ScopedValue, @with
 
 include("types.jl")
 include("functions.jl")

--- a/src/OhMyThreads.jl
+++ b/src/OhMyThreads.jl
@@ -15,6 +15,13 @@ export chunks, index_chunks
 
 using TaskLocalValues: TaskLocalValues
 const TaskLocalValue = TaskLocalValues.TaskLocalValue
+
+if isdefined(Base, :ScopedValues)
+    using Base.ScopedValues: ScopedValues, ScopedValue, @with
+else
+    using ScopedValues: ScopedValues, ScopedValue, @with
+end
+
 include("types.jl")
 include("functions.jl")
 include("macros.jl")
@@ -26,7 +33,7 @@ using .Schedulers: Scheduler, DynamicScheduler, StaticScheduler, GreedyScheduler
 include("implementation.jl")
 include("experimental.jl")
 
-export @tasks, @set, @local, @one_by_one, @only_one
+export @tasks, @set, @local, @one_by_one, @only_one, @allow_boxed_captures, @disallow_boxed_captures
 export treduce, tmapreduce, treducemap, tmap, tmap!, tforeach, tcollect
 export Scheduler, DynamicScheduler, StaticScheduler, GreedyScheduler, SerialScheduler
 

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -308,7 +308,7 @@ function throw_if_boxed_captures(f)
     T = typeof(f)
     if any(FT -> FT <: Core.Box, fieldtypes(T))
         boxed_fields = join((fieldname(T, i) for i in 1:fieldcount(T) if fieldtype(T,i) <: Core.Box), ", ")
-        error("Attempted to capture and modify outer local variable(s) $boxed_fields, which would cause a race condition. Consider marking these variables as local inside their respective closure, or redesigning your code to avoid a race condition.")
+        error("Attempted to capture and modify outer local variable(s) $boxed_fields, which would be not only slow, but could also cause a race condition. Consider marking these variables as local inside their respective closure, or redesigning your code to avoid a race condition. If these variables are inside a @one_by_one or @only_one block, consider using a mutable Ref instead of re-binding the variable.")
     end
     for i ∈ 1:fieldcount(T)
         # recurse into nested captured functions.

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -93,6 +93,7 @@ end
 
 treducemap(op, f, A...; kwargs...) = tmapreduce(f, op, A...; kwargs...)
 
+
 # DynamicScheduler: AbstractArray/Generic
 function _tmapreduce(f,
         op,
@@ -102,6 +103,7 @@ function _tmapreduce(f,
         mapreduce_kwargs)::OutputType where {OutputType}
     (; threadpool) = scheduler
     check_all_have_same_indices(Arrs)
+    throw_if_boxed_captures(f, op)
     if chunking_enabled(scheduler)
         tasks = map(_index_chunks(scheduler, first(Arrs))) do inds
             args = map(A -> view(A, inds), Arrs)
@@ -128,6 +130,7 @@ function _tmapreduce(f,
         scheduler::DynamicScheduler,
         mapreduce_kwargs)::OutputType where {OutputType, T}
     (; threadpool) = scheduler
+    throw_if_boxed_captures(f, op)
     tasks = map(only(Arrs)) do idcs
         @spawn threadpool promise_task_local(f)(idcs)
     end
@@ -143,6 +146,7 @@ function _tmapreduce(f,
         mapreduce_kwargs)::OutputType where {OutputType}
     nt = nthreads()
     check_all_have_same_indices(Arrs)
+    throw_if_boxed_captures(f, op)
     if chunking_enabled(scheduler)
         tasks = map(enumerate(_index_chunks(scheduler, first(Arrs)))) do (c, inds)
             tid = @inbounds nthtid(mod1(c, nt))
@@ -175,6 +179,7 @@ function _tmapreduce(f,
         scheduler::StaticScheduler,
         mapreduce_kwargs)::OutputType where {OutputType, T}
     check_all_have_same_indices(Arrs)
+    throw_if_boxed_captures(f, op)
     chnks = only(Arrs)
     nt = nthreads()
     tasks = map(enumerate(chnks)) do (c, idcs)
@@ -207,6 +212,7 @@ function _tmapreduce(f,
         ntasks = min(length(first(Arrs)), ntasks_desired)
         ch_len = length(first(Arrs))
     end
+    throw_if_boxed_captures(f, op)
     # TODO: Use ChannelLike for iterators that support it. Dispatch on IndexLinear?
     ch = Channel{Tuple{eltype.(Arrs)...}}(ch_len; spawn = true) do ch
         for args in zip(Arrs...)
@@ -252,6 +258,7 @@ function _tmapreduce(f,
         throw(ArgumentError("SizeUnkown iterators in combination with a greedy scheduler and chunking are currently not supported."))
     end
     check_all_have_same_indices(Arrs)
+    throw_if_boxed_captures(f, op)
     chnks = _index_chunks(scheduler, first(Arrs))
     ntasks_desired = scheduler.ntasks
     ntasks = min(length(chnks), ntasks_desired)
@@ -294,6 +301,30 @@ function check_all_have_same_indices(Arrs)
             error("The indices of the input arrays must match the indices of the output array.")
         end
     end
+end
+
+
+function throw_if_boxed_captures(f)
+    T = typeof(f)
+    if any(FT -> FT <: Core.Box, fieldtypes(T))
+        boxed_fields = join((fieldname(T, i) for i in 1:fieldcount(T) if fieldtype(T,i) <: Core.Box), ", ")
+        error("Attempted to capture and modify outer local variable(s) $boxed_fields, which would cause a race condition. Consider marking these variables as local inside their respective closure, or redesigning your code to avoid a race condition.")
+    end
+    for i ∈ 1:fieldcount(T)
+        # recurse into nested captured functions.
+        if fieldtype(T, i) <: Function
+            f_inner = getfield(f, i)
+            if f !== f_inner
+                # don't recurse into self!
+                throw_if_boxed_captures(getfield(f, i))
+            end
+        end
+    end
+end
+
+function throw_if_boxed_captures(f, fs...)
+    throw_if_boxed_captures(f)
+    throw_if_boxed_captures(fs...)
 end
 
 #-------------------------------------------------------------
@@ -381,6 +412,7 @@ function _tmap(scheduler::DynamicScheduler{NoChunking},
         _Arrs::AbstractArray...;)
     (; threadpool) = scheduler
     Arrs = (A, _Arrs...)
+    throw_if_boxed_captures(f)
     tasks = map(eachindex(A)) do i
         @spawn threadpool begin
             args = map(A -> A[i], Arrs)
@@ -397,6 +429,7 @@ function _tmap(scheduler::DynamicScheduler{NoChunking},
         A::Union{AbstractChunks, ChunkSplitters.Internals.Enumerate},
         _Arrs::AbstractArray...)
     (; threadpool) = scheduler
+    throw_if_boxed_captures(f)
     tasks = map(A) do idcs
         @spawn threadpool promise_task_local(f)(idcs)
     end
@@ -409,6 +442,7 @@ function _tmap(scheduler::StaticScheduler{NoChunking},
         A::AbstractChunks,
         _Arrs::AbstractArray...)
     nt = nthreads()
+    throw_if_boxed_captures(f)
     tasks = map(enumerate(A)) do (c, idcs)
         tid = @inbounds nthtid(mod1(c, nt))
         @spawnat tid promise_task_local(f)(idcs)
@@ -423,6 +457,7 @@ function _tmap(scheduler::StaticScheduler{NoChunking},
         _Arrs::AbstractArray...;)
     Arrs = (A, _Arrs...)
     nt = nthreads()
+    throw_if_boxed_captures(f)
     tasks = map(enumerate(A)) do (c, i)
         tid = @inbounds nthtid(mod1(c, nt))
         @spawnat tid begin
@@ -465,6 +500,7 @@ end
         map!(f, out, Arrs...)
     else
         @boundscheck check_all_have_same_indices((out, Arrs...))
+        throw_if_boxed_captures(f)
         mapping_f = maybe_rewrap(f) do f
             function mapping_function(i)
                 args = map(A -> @inbounds(A[i]), Arrs)

--- a/src/macro_impl.jl
+++ b/src/macro_impl.jl
@@ -284,7 +284,7 @@ function _maybe_handle_atonebyone_blocks!(args)
         init_lock_ex = :($(onebyone) = Base.ReentrantLock())
         push!(setup_onebyone_blocks.args, init_lock_ex)
         args[i] = quote
-            $(esc(:lock))($(onebyone)) do
+            lock($(onebyone)) do
                 $(esc(body))
             end
         end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -216,3 +216,91 @@ end
 macro one_by_one(args...)
     error("The @one_by_one macro may only be used inside of a @tasks block.")
 end
+
+
+const allowing_boxed_captures = ScopedValue(false)
+
+"""
+    @allow_boxed_captures expr
+
+By default, OhMyThreads.jl will detect and error on multithreaded code which references local variables
+which are 'boxed' -- something that happens if the variable could be re-bound in multiple scopes. This
+process can cause very sublte bugs in multithreaded code by creating silent race conditions, e.g.
+
+```julia
+let
+    function wrong()
+        tmap(1:10) do i
+            A = i # define A for the first time (lexically)
+            sleep(rand()/10)
+            A # user is trying to reference local A only
+        end
+    end
+    @show wrong()
+    A = 1 # boxed! this hoists "A" to the same variable as in `wrong` but presumably the user wanted a new one
+end
+```
+In this example, you might expect to get `[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]`, but you would actually observe
+incorrect results because `A` is 'boxed'. The fix for this would be to write something like
+```julia
+let
+    function right()
+        tmap(1:10) do i
+            local A = i
+            sleep(rand()/10)
+            A 
+        end
+    end
+    @show right()
+    A = 1
+end
+```
+
+However, if you are really sure you want to bypass OhMyThreads's error mechanism, you can use
+`@allow_boxed_captures` to wrap code you believe is okay, e.g.
+
+```julia-repl
+julia> let A = 1 
+           @allow_boxed_captures tmap(1:10) do i
+               A = i
+               sleep(rand()/10)
+               A # race condition!
+           end
+       end
+10-element Vector{Int64}:
+ 4
+ 2
+ 7
+ 2
+ 2
+ 8
+ 6
+ 8
+ 7
+ 2
+```
+
+This is a dynamically scoped construct, so this effect will apply to *all* nested code inside of `expr`.
+
+See also `@disallow_boxed_captures`
+"""
+macro allow_boxed_captures(ex)
+    quote
+        @with allowing_boxed_captures => true $(esc(ex))
+    end
+end
+
+"""
+    @disallow_boxed_captures expr
+
+Disable the effect of `@allow_boxed_captures` for any code in `expr`.
+
+This is a dynamically scoped construct, so this effect will apply to *all* nested code inside of `expr`.
+
+See also `@disallow_boxed_captures`
+"""
+macro disallow_boxed_captures(ex)
+    quote
+        @with allowing_boxed_captures => false $(esc(ex))
+    end
+end

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -1,7 +1,7 @@
 using Aqua
 
 @testset "Aqua.jl" begin
-  ignore = isdefined(Base, :ScopedValues) ? [:ScopedValues] : []
+  ignore = isdefined(Base, :ScopedValues) ? [:ScopedValues] : Symbol[]
   Aqua.test_all(
     OhMyThreads;
     # ambiguities=(exclude=[SomePackage.some_function], broken=true),

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -1,11 +1,12 @@
 using Aqua
 
 @testset "Aqua.jl" begin
+  ignore = isdefined(Base, :ScopedValues) ? [:ScopedValues] : []
   Aqua.test_all(
     OhMyThreads;
     # ambiguities=(exclude=[SomePackage.some_function], broken=true),
-    # stale_deps=(ignore=[:SomePackage],),
-    deps_compat=(ignore=[:Test],),
+    stale_deps=(ignore=[:ScopedValues],),
+    deps_compat=(;ignore,),
     # piracies=false,
     persistent_tasks=false,
   )

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -4,8 +4,8 @@ using Aqua
   Aqua.test_all(
     OhMyThreads;
     # ambiguities=(exclude=[SomePackage.some_function], broken=true),
-    # stale_deps=(ignore=[SomePackage],),
-    deps_compat=(;ignore,),
+    # stale_deps=(ignore=[:SomePackage],),
+    deps_compat=(ignore=[:Test],),
     # piracies=false,
     persistent_tasks=false,
   )

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -1,11 +1,10 @@
 using Aqua
 
 @testset "Aqua.jl" begin
-  ignore = isdefined(Base, :ScopedValues) ? [:ScopedValues] : Symbol[]
   Aqua.test_all(
     OhMyThreads;
     # ambiguities=(exclude=[SomePackage.some_function], broken=true),
-    stale_deps=(ignore=[:ScopedValues],),
+    # stale_deps=(ignore=[SomePackage],),
     deps_compat=(;ignore,),
     # piracies=false,
     persistent_tasks=false,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -710,4 +710,41 @@ end
     @test test_f() == 10
 end
 
+
+@testset "Boxing detection and error" begin
+    let
+        f1() = tmap(1:10) do i
+            A = i
+            sleep(rand()/10)
+            A
+        end
+        f2() = tmap(1:10) do i
+            local A = i
+            sleep(rand()/10)
+            A
+        end
+
+        @test f1() == 1:10
+        @test f2() == 1:10
+    end
+
+    let
+        f1() = tmap(1:10) do i
+            A = i
+            sleep(rand()/10)
+            A
+        end
+        f2() = tmap(1:10) do i
+            local A = i
+            sleep(rand()/10)
+            A
+        end
+
+        @test_throws ErrorException f1()
+        @test f2() == 1:10
+        
+        A = 1 # Cause spooky action-at-a-distance by making A outer-local to the whole let block!
+    end
+end
+
 # Todo way more testing, and easier tests to deal with

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -760,7 +760,7 @@ end
         end
         @test_throws ErrorException f1() == ones(10) # Throws even though the redefinition is 'harmless'
 
-        @allow_boxed_variables begin
+        @allow_boxed_captures begin
             f2() = tmap(1:10) do i
                 A = 1
             end
@@ -769,13 +769,13 @@ end
 
         # Can nest allow and disallow because they're scoped values!
         function f3()
-            @disallow_boxed_variables begin
+            @disallow_boxed_captures begin
                 tmap(1:10) do i
                 A = 1
                 end
             end
         end
-        @allow_boxed_variables begin
+        @allow_boxed_captures begin
             @test_throws ErrorException f3() == ones(10)
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -752,6 +752,35 @@ end
         
         A = 1 # Cause spooky action-at-a-distance by making A outer-local to the whole let block!
     end
+
+    let
+        A = 1
+        f1() = tmap(1:10) do i
+            A = 1
+        end
+        @test_throws ErrorException f1() == ones(10) # Throws even though the redefinition is 'harmless'
+
+        @allow_boxed_variables begin
+            f2() = tmap(1:10) do i
+                A = 1
+            end
+            @test f2() == ones(10)
+        end
+
+        # Can nest allow and disallow because they're scoped values!
+        function f3()
+            @disallow_boxed_variables begin
+                tmap(1:10) do i
+                A = 1
+                end
+            end
+        end
+        @allow_boxed_variables begin
+            @test_throws ErrorException f3() == ones(10)
+        end
+    end
+    
+    
 end
 
 # Todo way more testing, and easier tests to deal with


### PR DESCRIPTION
Closes #132, Closes #133

Before:
```julia
julia> let
           v = tmap(1:10) do i
               A = i
               sleep(rand())
               A
           end
           A = 1 # oops, now everything is a race condition!
           v
       end
10-element Vector{Int64}:
 9
 2
 2
 4
 2
 4
 9
 2
 9
 2
```
This PR:
```julia
julia> let
           v = tmap(1:10) do i
               A = i
               sleep(rand())
               A
           end
           A = 1 # oops, now everything is a race condition!
           v
       end
ERROR: Attempted to capture and modify outer local variable(s) A, which would be not only slow, but could also cause a race condition. Consider marking these variables as local inside their respective closure, or redesigning your code to avoid the race condition.

If these variables are inside a @one_by_one or @only_one block, consider using a mutable Ref instead of re-binding the variable.

This error can be bypassed with the @allow_boxed_captures macro.
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] throw_if_boxed_captures(f::Function)
    @ OhMyThreads.Implementation ~/Dropbox/Julia/OhMyThreads/src/implementation.jl:314
  [3] throw_if_boxed_captures(f::Function)
    @ OhMyThreads.Implementation ~/Dropbox/Julia/OhMyThreads/src/implementation.jl:322
  [4] throw_if_boxed_captures
    @ ~/Dropbox/Julia/OhMyThreads/src/implementation.jl:329 [inlined]
  [5] _tmapreduce(f::Function, op::Function, Arrs::Tuple{…}, ::Type{…}, scheduler::DynamicScheduler{…}, mapreduce_kwargs::@NamedTuple{})
...
```

This new behaviour can be opted out of with the new `@allow_boxed_captures` macro:
```julia
julia> @allow_boxed_captures let
           v = tmap(1:10) do i
               A = i
               sleep(rand())
               A
           end
           A = 1 # oops, now everything is a race condition!
           v
       end
10-element Vector{Int64}:
 4
 2
 8
 4
 3
 6
 6
 2
 6
 6
```