### PR TITLE
Various CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
           - 'pre'
         os:
           - ubuntu-latest
-          - macos-13
           - windows-latest
         arch:
           - x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,17 @@ jobs:
           - 'pre'
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-13
           - windows-latest
         arch:
           - x64
+        include:
+          - os: macos-latest
+            arch: aarch64
+            version: '1.10'
+          - os: macos-latest
+            arch: aarch64
+            version: 'pre'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
@@ -27,9 +34,9 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          JULIA_NUM_THREADS: 4,2
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
-        env:
-          JULIA_NUM_THREADS: 4,2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ using OhMyThreads: Consecutive, RoundRobin
 using OhMyThreads.Experimental: @barrier
 using OhMyThreads.Implementation: BoxedVariableError
 
+@info "Testing with $(Threads.nthreads(:default)),$(Threads.nthreads(:interactive)) threads."
+
 include("Aqua.jl")
 
 sets_to_test = [(~ = isapprox, f = sin ∘ *, op = +,
@@ -544,7 +546,7 @@ end
             end
         end
 
-        let 
+        let
             x = Ref(0)
             y = Ref(0)
             try
@@ -758,7 +760,7 @@ end
          ├ Chunking: fixed count ($(10 * nt)), split :roundrobin
          └ Threadpool: default"""
 end
-  
+
 @testset "Boxing detection and error" begin
     let
         f1() = tmap(1:10) do i
@@ -790,7 +792,7 @@ end
 
         @test_throws BoxedVariableError f1()
         @test f2() == 1:10
-        
+
         A = 1 # Cause spooky action-at-a-distance by making A outer-local to the whole let block!
     end
 


### PR DESCRIPTION
2 fixes:
- x64 macOS is only available on `macos-13` so change to that. I also re-add aarch64 tests because that is the more common configuration so continue testing that.
- `env` must be set per-step. I assume the step that needs to be run with multiple threads is `julia-runtests` so I changed it. I can undo if I was wrong.