### PR TITLE
Support `minsize` setting; don't spawn tasks when only 1 chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ OhMyThreads.jl Changelog
 
 Version 0.8.2
 ------------
-- ![Feature][badge-feature] Added a `minsize` chunking argument for schedulers, so that they can specify a lower bound on the size of chunks which are worth parallelizing. For example, `treduce(+, 1:10; minsize=100)` will run serially, but `treduce(+, 1:1000000; minsize=100)` will be parallelized.
-- ![Enhancement][badge-enhancement] Operations on collections with only one 'chunk' no longer spawn an unnecessary task. That means operations like `treduce(+, 1:10; nchunks=1)` will have less overhead. 
+- ![Feature][badge-feature] Added a `minchunksize` chunking argument for schedulers, so that they can specify a lower bound on the size of chunks which are worth parallelizing. For example, `treduce(+, 1:10; minchunksize=100)` will run serially, but `treduce(+, 1:1000000; minchunksize=100)` will be parallelized.
+- ![Enhancement][badge-enhancement] Operations on collections with only one 'chunk' no longer spawn an unnecessary task. That means operations like `treduce(+, 1:10; minchunksize=100)` will have less overhead.
 
 Version 0.8.1
 ------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 OhMyThreads.jl Changelog
 =========================
 
+Version 0.8.2
+------------
+- ![Feature][badge-feature] Added a `minsize` chunking argument for schedulers, so that they can specify a lower bound on the size of chunks which are worth parallelizing. For example, `treduce(+, 1:10; minsize=100)` will run serially, but `treduce(+, 1:1000000; minsize=100)` will be parallelized.
+- ![Enhancement][badge-enhancement] Operations on collections with only one 'chunk' no longer spawn an unnecessary task. That means operations like `treduce(+, 1:10; nchunks=1)` will have less overhead. 
+
 Version 0.8.1
 ------------
 - ![Feature][badge-feature] Added a `@localize` macro which turns `@localize x y expr` into `let x=x, y=y; expr end` ([#142][gh-pr-142])

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ MarkdownExt = "Markdown"
 [compat]
 Aqua = "0.8"
 BangBang = "0.3.40, 0.4"
-ChunkSplitters = "3.1.1"
+ChunkSplitters = "3.1"
 Markdown = "1"
 ScopedValues = "1.3"
 StableTasks = "0.1.5"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ MarkdownExt = "Markdown"
 [compat]
 Aqua = "0.8"
 BangBang = "0.3.40, 0.4"
-ChunkSplitters = "3"
+ChunkSplitters = "3.1.1"
 Markdown = "1"
 ScopedValues = "1.3"
 StableTasks = "0.1.5"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ MarkdownExt = "Markdown"
 [compat]
 Aqua = "0.8"
 BangBang = "0.3.40, 0.4"
-ChunkSplitters = "3.1.2"
+ChunkSplitters = "3"
 Markdown = "1"
 ScopedValues = "1.3"
 StableTasks = "0.1.5"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ MarkdownExt = "Markdown"
 [compat]
 Aqua = "0.8"
 BangBang = "0.3.40, 0.4"
-ChunkSplitters = "3"
+ChunkSplitters = "3.1.2"
 Markdown = "1"
 ScopedValues = "1.3"
 StableTasks = "0.1.5"

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -7,7 +7,7 @@ using OhMyThreads: Scheduler,
                    DynamicScheduler, StaticScheduler, GreedyScheduler,
                    SerialScheduler
 using OhMyThreads.Schedulers: chunking_enabled,
-                              nchunks, chunksize, chunksplit, minsize, has_chunksplit,
+                              nchunks, chunksize, chunksplit, minchunksize, has_chunksplit,
                               chunking_mode, ChunkingMode, NoChunking,
                               FixedSize, FixedCount, scheduler_from_symbol, NotGiven,
                               isgiven
@@ -25,7 +25,7 @@ function _index_chunks(sched, arg)
     C = chunking_mode(sched)
     @assert C != NoChunking
     if C == FixedCount
-        msz = isnothing(minsize(sched)) ? nothing : min(minsize(sched), length(arg))
+        msz = isnothing(minchunksize(sched)) ? nothing : min(minchunksize(sched), length(arg))
         index_chunks(arg;
             n = nchunks(sched),
             split = chunksplit(sched),
@@ -35,7 +35,7 @@ function _index_chunks(sched, arg)
         index_chunks(arg;
             size = chunksize(sched),
             split = chunksplit(sched),
-            minsize = minsize(sched))::IndexChunks{
+            minsize = minchunksize(sched))::IndexChunks{
             typeof(arg), ChunkSplitters.Internals.FixedSize}
     end
 end
@@ -75,10 +75,10 @@ function has_multiple_chunks(scheduler, coll)
     if C == NoChunking || coll isa Union{AbstractChunks, ChunkSplitters.Internals.Enumerate}
         length(coll) > 1
     elseif C == FixedCount
-        if isnothing(minsize(scheduler))
+        if isnothing(minchunksize(scheduler))
             mcs = 1
         else
-            mcs = max(min(minsize(scheduler), length(coll)), 1)
+            mcs = max(min(minchunksize(scheduler), length(coll)), 1)
         end
         min(length(coll) ÷ mcs, nchunks(scheduler)) > 1
     elseif C == FixedSize

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -74,7 +74,11 @@ function has_multiple_chunks(scheduler, coll)
     if C == NoChunking || coll isa Union{AbstractChunks, ChunkSplitters.Internals.Enumerate}
         length(coll) > 1
     elseif C == FixedCount
-        mcs = max(min(minsize(scheduler), length(coll)), 1)
+        if isnothing(minsize(scheduler))
+            mcs = max(length(coll), 1)
+        else
+            mcs = max(min(minsize(scheduler), length(coll)), 1)
+        end
         min(length(coll) ÷ mcs, nchunks(scheduler)) > 1
     elseif C == FixedSize
         length(coll) ÷ chunksize(scheduler) > 1

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -25,10 +25,11 @@ function _index_chunks(sched, arg)
     C = chunking_mode(sched)
     @assert C != NoChunking
     if C == FixedCount
+        msz = isnothing(minsize(sched)) ? nothing : min(minsize(sched), length(arg))
         index_chunks(arg;
             n = nchunks(sched),
             split = chunksplit(sched),
-            minsize = minsize(sched))::IndexChunks{
+            minsize = msz)::IndexChunks{
             typeof(arg), ChunkSplitters.Internals.FixedCount}
     elseif C == FixedSize
         index_chunks(arg;

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -75,7 +75,7 @@ function has_multiple_chunks(scheduler, coll)
         length(coll) > 1
     elseif C == FixedCount
         if isnothing(minsize(scheduler))
-            mcs = max(length(coll), 1)
+            mcs = 1
         else
             mcs = max(min(minsize(scheduler), length(coll)), 1)
         end

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -70,10 +70,14 @@ function _check_chunks_incompatible_kwargs(; kwargs...)
 end
 
 function has_multiple_chunks(scheduler, coll)
-    if chunking_mode(scheduler) == NoChunking || coll isa Union{AbstractChunks, ChunkSplitters.Internals.Enumerate}
+    C = chunking_mode(scheduler)
+    if C == NoChunking || coll isa Union{AbstractChunks, ChunkSplitters.Internals.Enumerate}
         length(coll) > 1
-    else
-        length(_index_chunks(scheduler, coll)) > 1
+    elseif C == FixedCount
+        mcs = max(min(minsize(scheduler), length(coll)), 1)
+        min(length(coll) ÷ mcs, nchunks(scheduler)) > 1
+    elseif C == FixedSize
+        length(coll) ÷ chunksize(scheduler) > 1
     end
 end
 

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -140,7 +140,7 @@ end
 function _chunkingstr(ca::ChunkingArgs{FixedSize})
     str = "fixed size ($(ca.size)), split :$(_splitid(ca.split))"
     if has_minsize(ca)
-        str = str * ", min chunksize $(ca.minsize)"
+        str = str * ", minimum chunk size $(ca.minsize)"
     end
     str
 end

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -133,15 +133,12 @@ _chunkingstr(ca::ChunkingArgs{NoChunking}) = "none"
 function _chunkingstr(ca::ChunkingArgs{FixedCount})
     str = "fixed count ($(ca.n)), split :$(_splitid(ca.split))"
     if has_minsize(ca)
-        str = str * ", min chunksize $(ca.minsize)"
+        str = str * ", minimum chunk size  $(ca.minsize)"
     end
     str
 end
 function _chunkingstr(ca::ChunkingArgs{FixedSize})
     str = "fixed size ($(ca.size)), split :$(_splitid(ca.split))"
-    if has_minsize(ca)
-        str = str * ", minimum chunk size $(ca.minsize)"
-    end
     str
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,15 +28,15 @@ ChunkedGreedy(; kwargs...) = GreedyScheduler(; kwargs...)
                 SerialScheduler, ChunkedGreedy)
                 @testset for split in (Consecutive(), RoundRobin(), :consecutive, :roundrobin)
                     for nchunks in (1, 2, 6)
-                        for minsize ∈ (nothing, 1, 3)
+                        for minchunksize ∈ (nothing, 1, 3)
                             if sched == GreedyScheduler
-                                scheduler = sched(; ntasks = nchunks, minsize)
+                                scheduler = sched(; ntasks = nchunks, minchunksize)
                             elseif sched == DynamicScheduler{OhMyThreads.Schedulers.NoChunking}
                                 scheduler = DynamicScheduler(; chunking = false)
                             elseif sched == SerialScheduler
                                 scheduler = SerialScheduler()
                             else
-                                scheduler = sched(; nchunks, split, minsize)
+                                scheduler = sched(; nchunks, split, minchunksize)
                             end
                             kwargs = (; scheduler)
                             if (split in (RoundRobin(), :roundrobin) ||
@@ -187,7 +187,7 @@ end;
         i
     end) |> isnothing
     @test @tasks(for i in 1:4
-        @set minsize=2
+        @set minchunksize=2
         i
     end) |> isnothing
     @test_throws ArgumentError @tasks(for i in 1:3
@@ -391,8 +391,8 @@ end;
     @test tmapreduce(sin, +, 1:10000; split = RoundRobin()) ≈ res_tmr
     @test tmapreduce(sin, +, 1:10000; chunksize = 2) ≈ res_tmr
     @test tmapreduce(sin, +, 1:10000; chunking = false) ≈ res_tmr
-    @test tmapreduce(sin, +, 1:10000; minsize=10) ≈ res_tmr
-    @test tmapreduce(sin, +, 1:10; minsize=10) == mapreduce(sin, +, 1:10)
+    @test tmapreduce(sin, +, 1:10000; minchunksize=10) ≈ res_tmr
+    @test tmapreduce(sin, +, 1:10; minchunksize=10) == mapreduce(sin, +, 1:10)
     
     # scheduler isa Scheduler
     @test tmapreduce(sin, +, 1:10000; scheduler = StaticScheduler()) ≈ res_tmr


### PR DESCRIPTION
Closes #114 and closes #72

This PR does two things:

1. It makes it so that reductions over a single chunk / (or single element in the case of no-chunking) will not hit the multithreaded path, and will instead just call `Base.mapreduce`
2. It adds a `minsize` keyword argument for schedulers so that users can say "I don't want any chunks smaller than `N` elements.

Together, this means that you can do stuff like
```julia
julia> @btime tmapreduce(sin, +, 1:10; minsize=100)
  75.105 ns (3 allocations: 96 bytes)
1.4111883712180104
```
and only get a minor amount of overhead versus regular `mapreduce`.