### PR TITLE
Small optimizations on Scheduler creation

### DIFF
--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -89,7 +89,10 @@ function has_multiple_chunks(scheduler, coll)
     end
 end
 
-function tmapreduce(f, op, Arrs...;
+# we can inline this function because we use @noinline on the main function
+# it can save some time in cases where we do not hit the main function (e.g. when
+# fallback to mapreduce without any threading)
+@inline function tmapreduce(f, op, Arrs...;
         scheduler::MaybeScheduler = NotGiven(),
         outputtype::Type = Any,
         init = NotGiven(),

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -8,6 +8,7 @@ using OhMyThreads: Scheduler,
                    SerialScheduler
 using OhMyThreads.Schedulers: chunking_enabled,
                               nchunks, chunksize, chunksplit, minchunksize, has_chunksplit,
+                              has_minchunksize,
                               chunking_mode, ChunkingMode, NoChunking,
                               FixedSize, FixedCount, scheduler_from_symbol, NotGiven,
                               isgiven
@@ -25,7 +26,7 @@ function _index_chunks(sched, arg)
     C = chunking_mode(sched)
     @assert C != NoChunking
     if C == FixedCount
-        msz = isnothing(minchunksize(sched)) ? nothing : min(minchunksize(sched), length(arg))
+        msz = !has_minchunksize(sched) ? nothing : min(minchunksize(sched), length(arg))
         index_chunks(arg;
             n = nchunks(sched),
             split = chunksplit(sched),
@@ -75,7 +76,7 @@ function has_multiple_chunks(scheduler, coll)
     if C == NoChunking || coll isa Union{AbstractChunks, ChunkSplitters.Internals.Enumerate}
         length(coll) > 1
     elseif C == FixedCount
-        if isnothing(minchunksize(scheduler))
+        if !has_minchunksize(scheduler)
             mcs = 1
         else
             mcs = max(min(minchunksize(scheduler), length(coll)), 1)

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -59,7 +59,7 @@ function scheduler_from_symbol(s::Symbol; kwargs...)
     s == :dynamic && return DynamicScheduler(; kwargs...)
     s == :static && return StaticScheduler(; kwargs...)
     s == :greedy && return GreedyScheduler(; kwargs...)
-    s == :serial && return SerialScheduler()
+    s == :serial && return SerialScheduler(; kwargs...)
     return scheduler_from_symbol(Val(s), kwargs...)
 end
 

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -45,22 +45,10 @@ abstract type Scheduler end
 
 from_symbol(::Val) = throw(ArgumentError("unkown scheduler symbol"))
 
-function scheduler_from_symbol(v::Val, ; kwargs...)
+scheduler_from_symbol(s::Symbol; kwargs...) = scheduler_from_symbol(Val(s); kwargs...)
+function scheduler_from_symbol(v::Val; kwargs...)
     sched = from_symbol(v)
     return sched(; kwargs...)
-end
-
-function scheduler_from_symbol(s::Symbol; kwargs...)
-    # we could simply use the last line
-    # but there is a high chance to have a runtime dispatch to pass from Symbol to Val
-    # so we do the dispatch by hand as much as possible
-    # There will always be a performance penalty because the output
-    # of this function is not known at compile time.
-    s == :dynamic && return DynamicScheduler(; kwargs...)
-    s == :static && return StaticScheduler(; kwargs...)
-    s == :greedy && return GreedyScheduler(; kwargs...)
-    s == :serial && return SerialScheduler(; kwargs...)
-    return scheduler_from_symbol(Val(s), kwargs...)
 end
 
 """
@@ -105,7 +93,7 @@ function ChunkingArgs(
         n::MaybeInteger,
         size::MaybeInteger,
         split::Union{Symbol, Split};
-        minsize::MaybeInteger,
+        minsize=nothing,
         chunking
 )
     chunking || return ChunkingArgs(NoChunking)

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -97,9 +97,9 @@ struct ChunkingArgs{C, S <: Split}
     n::Int
     size::Int
     split::S
-    minsize::Int
+    minsize::Union{Int, Nothing}
 end
-ChunkingArgs(::Type{NoChunking}) = ChunkingArgs{NoChunking, NoSplit}(-1, -1, NoSplit(), -1)
+ChunkingArgs(::Type{NoChunking}) = ChunkingArgs{NoChunking, NoSplit}(-1, -1, NoSplit(), nothing)
 function ChunkingArgs(
         Sched::Type{<:Scheduler},
         n::MaybeInteger,
@@ -109,10 +109,6 @@ function ChunkingArgs(
         chunking
 )
     chunking || return ChunkingArgs(NoChunking)
-
-    if !isgiven(minsize)
-        minsize = -1
-    end
 
     if !isgiven(n) && !isgiven(size)
         n = default_nchunks(Sched)
@@ -142,7 +138,7 @@ chunking_mode(::ChunkingArgs{C}) where {C} = C
 has_n(ca::ChunkingArgs) = ca.n > 0
 has_size(ca::ChunkingArgs) = ca.size > 0
 has_split(::ChunkingArgs{C, S}) where {C, S} = S !== NoSplit
-has_minsize(ca::ChunkingArgs) = ca.minsize > 0
+has_minsize(ca::ChunkingArgs) = !isnothing(ca.minsize)
 chunking_enabled(ca::ChunkingArgs) = chunking_mode(ca) != NoChunking
 
 _chunkingstr(ca::ChunkingArgs{NoChunking}) = "none"
@@ -237,7 +233,7 @@ function DynamicScheduler(;
         chunksize::MaybeInteger = NotGiven(),
         chunking::Bool = true,
         split::Union{Split, Symbol} = Consecutive(),
-        minchunksize::MaybeInteger = NotGiven())
+        minchunksize::Union{Integer, Nothing} = nothing)
     if isgiven(ntasks)
         if isgiven(nchunks)
             throw(ArgumentError("For the dynamic scheduler, nchunks and ntasks are aliases and only one may be provided"))
@@ -299,7 +295,7 @@ function StaticScheduler(;
         chunksize::MaybeInteger = NotGiven(),
         chunking::Bool = true,
         split::Union{Split, Symbol} = Consecutive(),
-        minchunksize::MaybeInteger = NotGiven())
+        minchunksize::Union{Integer, Nothing} = nothing)
     if isgiven(ntasks)
         if isgiven(nchunks)
             throw(ArgumentError("For the static scheduler, nchunks and ntasks are aliases and only one may be provided"))
@@ -369,7 +365,7 @@ function GreedyScheduler(;
         chunksize::MaybeInteger = NotGiven(),
         chunking::Bool = false,
         split::Union{Split, Symbol} = RoundRobin(),
-        minchunksize::MaybeInteger = NotGiven())
+        minchunksize::Union{Integer, Nothing} = nothing)
     if isgiven(nchunks) || isgiven(chunksize)
         chunking = true
     end

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -1,7 +1,7 @@
 module Schedulers
 
 using Base.Threads: nthreads
-using ChunkSplitters: Split, Consecutive, RoundRobin
+using ChunkSplitters: Split, Consecutive, RoundRobin, ChunkSplitters
 
 # Used to indicate that a keyword argument has not been set by the user.
 # We don't use Nothing because nothing maybe sometimes be a valid user input (e.g. for init)
@@ -65,6 +65,9 @@ struct NoChunking <: ChunkingMode end
 struct FixedCount <: ChunkingMode end
 struct FixedSize <: ChunkingMode end
 
+chunksplitter_mode(::Type{FixedCount}) = ChunkSplitters.Internals.FixedCount
+chunksplitter_mode(::Type{FixedSize}) = ChunkSplitters.Internals.FixedSize
+
 """
     ChunkingArgs{C, S <: Split}(n::Int, size::Int, split::S)
     ChunkingArgs(Sched::Type{<:Scheduler}, n::MaybeInteger, size::MaybeInteger, split::Union{Symbol, Split}; chunking)
@@ -82,52 +85,45 @@ to know if the field is effectively used, since it is no longer
 `NotGiven` for type stability.
 """
 struct ChunkingArgs{C, S <: Split}
-    n::Int
-    size::Int
-    split::S
+    n::Union{Int, Nothing}
+    size::Union{Int, Nothing}
     minsize::Union{Int, Nothing}
+    split::S
 end
-ChunkingArgs(::Type{NoChunking}) = ChunkingArgs{NoChunking, NoSplit}(-1, -1, NoSplit(), nothing)
+function ChunkingArgs(::Type{NoChunking})
+    ChunkingArgs{NoChunking, NoSplit}(nothing, nothing, nothing, NoSplit())
+end
 function ChunkingArgs(
-        Sched::Type{<:Scheduler},
-        n::MaybeInteger,
-        size::MaybeInteger,
-        split::Union{Symbol, Split};
-        minsize=nothing,
+        Sched::Type{<:Scheduler};
+        n = nothing,
+        size = nothing,
+        minsize = nothing,
+        split::Union{Symbol, Split},
         chunking
 )
     chunking || return ChunkingArgs(NoChunking)
 
-    if !isgiven(n) && !isgiven(size)
+    if isnothing(n) && isnothing(size)
         n = default_nchunks(Sched)
-        size = -1
-    else
-        n = isgiven(n) ? n : -1
-        size = isgiven(size) ? size : -1
+    elseif !isnothing(n) && !isnothing(size)
+        throw(ArgumentError("nchunks and chunksize are mutually exclusive"))
     end
-
-    chunking_mode = size > 0 ? FixedSize : FixedCount
+    chunking_mode = isnothing(n) ? FixedSize : FixedCount
     split = _parse_split(split)
-    result = ChunkingArgs{chunking_mode, typeof(split)}(n, size, split, minsize)
-
-    # argument names in error messages are those of the scheduler constructor instead
-    # of ChunkingArgs because the user should not be aware of the ChunkingArgs type
-    # (e.g. `nchunks` instead of `n`)
-    if !(has_n(result) || has_size(result))
-        throw(ArgumentError("Either `nchunks` or `chunksize` must be a positive integer (or chunking=false)."))
-    end
-    if has_n(result) && has_size(result)
-        throw(ArgumentError("`nchunks` and `chunksize` are mutually exclusive and only one of them may be a positive integer"))
-    end
-    return result
+    return ChunkingArgs{chunking_mode, typeof(split)}(n, size, minsize, split)
 end
 
 chunking_mode(::ChunkingArgs{C}) where {C} = C
-has_n(ca::ChunkingArgs) = ca.n > 0
-has_size(ca::ChunkingArgs) = ca.size > 0
+has_n(ca::ChunkingArgs) = !isnothing(ca.n)
+has_size(ca::ChunkingArgs) = !isnothing(ca.size)
 has_split(::ChunkingArgs{C, S}) where {C, S} = S !== NoSplit
 has_minsize(ca::ChunkingArgs) = !isnothing(ca.minsize)
 chunking_enabled(ca::ChunkingArgs) = chunking_mode(ca) != NoChunking
+
+function chunkingargs_to_kwargs(ca::ChunkingArgs, arg)
+    minsize = !has_minsize(ca) ? nothing : min(ca.minsize, length(arg))
+    return (; ca.n, ca.size, minsize, ca.split)
+end
 
 _chunkingstr(ca::ChunkingArgs{NoChunking}) = "none"
 function _chunkingstr(ca::ChunkingArgs{FixedCount})
@@ -156,6 +152,10 @@ has_nchunks(sched::Scheduler) = has_n(chunking_args(sched))
 has_chunksize(sched::Scheduler) = has_size(chunking_args(sched))
 has_chunksplit(sched::Scheduler) = has_split(chunking_args(sched))
 has_minchunksize(sched::Scheduler) = has_minsize(chunking_args(sched))
+
+function chunkingargs_to_kwargs(sched::Scheduler, arg)
+    chunkingargs_to_kwargs(chunking_args(sched), arg)
+end
 
 chunking_mode(sched::Scheduler) = chunking_mode(chunking_args(sched))
 chunking_enabled(sched::Scheduler) = chunking_enabled(chunking_args(sched))
@@ -216,19 +216,21 @@ end
 
 function DynamicScheduler(;
         threadpool::Symbol = :default,
-        nchunks::MaybeInteger = NotGiven(),
-        ntasks::MaybeInteger = NotGiven(), # "alias" for nchunks
-        chunksize::MaybeInteger = NotGiven(),
-        chunking::Bool = true,
+        nchunks = nothing,
+        ntasks = nothing, # "alias" for nchunks
+        chunksize = nothing,
         split::Union{Split, Symbol} = Consecutive(),
-        minchunksize::Union{Integer, Nothing} = nothing)
-    if isgiven(ntasks)
-        if isgiven(nchunks)
+        minchunksize = nothing,
+        chunking::Bool = true
+)
+    if !isnothing(ntasks)
+        if !isnothing(nchunks)
             throw(ArgumentError("For the dynamic scheduler, nchunks and ntasks are aliases and only one may be provided"))
         end
         nchunks = ntasks
     end
-    ca = ChunkingArgs(DynamicScheduler, nchunks, chunksize, split; chunking, minsize=minchunksize)
+    ca = ChunkingArgs(DynamicScheduler;
+        n = nchunks, size = chunksize, minsize = minchunksize, split, chunking)
     return DynamicScheduler(threadpool, ca)
 end
 from_symbol(::Val{:dynamic}) = DynamicScheduler
@@ -278,19 +280,21 @@ struct StaticScheduler{C <: ChunkingMode, S <: Split} <: Scheduler
 end
 
 function StaticScheduler(;
-        nchunks::MaybeInteger = NotGiven(),
-        ntasks::MaybeInteger = NotGiven(), # "alias" for nchunks
-        chunksize::MaybeInteger = NotGiven(),
-        chunking::Bool = true,
+        nchunks = nothing,
+        ntasks = nothing, # "alias" for nchunks
+        chunksize = nothing,
+        minchunksize = nothing,
         split::Union{Split, Symbol} = Consecutive(),
-        minchunksize::Union{Integer, Nothing} = nothing)
-    if isgiven(ntasks)
-        if isgiven(nchunks)
+        chunking::Bool = true
+)
+    if !isnothing(ntasks)
+        if !isnothing(nchunks)
             throw(ArgumentError("For the static scheduler, nchunks and ntasks are aliases and only one may be provided"))
         end
         nchunks = ntasks
     end
-    ca = ChunkingArgs(StaticScheduler, nchunks, chunksize, split; chunking, minsize=minchunksize)
+    ca = ChunkingArgs(StaticScheduler;
+        n = nchunks, size = chunksize, minsize = minchunksize, split, chunking)
     return StaticScheduler(ca)
 end
 from_symbol(::Val{:static}) = StaticScheduler
@@ -349,15 +353,17 @@ end
 
 function GreedyScheduler(;
         ntasks::Integer = nthreads(),
-        nchunks::MaybeInteger = NotGiven(),
-        chunksize::MaybeInteger = NotGiven(),
-        chunking::Bool = false,
+        nchunks = nothing,
+        chunksize = nothing,
+        minchunksize = nothing,
         split::Union{Split, Symbol} = RoundRobin(),
-        minchunksize::Union{Integer, Nothing} = nothing)
-    if isgiven(nchunks) || isgiven(chunksize)
+        chunking::Bool = false
+)
+    if !(isnothing(nchunks) && isnothing(chunksize))
         chunking = true
     end
-    ca = ChunkingArgs(GreedyScheduler, nchunks, chunksize, split; chunking, minsize=minchunksize)
+    ca = ChunkingArgs(GreedyScheduler;
+        n = nchunks, size = chunksize, minsize = minchunksize, split, chunking)
     return GreedyScheduler(ntasks, ca)
 end
 from_symbol(::Val{:greedy}) = GreedyScheduler

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -45,9 +45,22 @@ abstract type Scheduler end
 
 from_symbol(::Val) = throw(ArgumentError("unkown scheduler symbol"))
 
-function scheduler_from_symbol(v::Val; kwargs...)
+function scheduler_from_symbol(v::Val, ; kwargs...)
     sched = from_symbol(v)
     return sched(; kwargs...)
+end
+
+function scheduler_from_symbol(s::Symbol; kwargs...)
+    # we could simply use the last line
+    # but there is a high chance to have a runtime dispatch to pass from Symbol to Val
+    # so we do the dispatch by hand as much as possible
+    # There will always be a performance penalty because the output
+    # of this function is not known at compile time.
+    s == :dynamic && return DynamicScheduler(; kwargs...)
+    s == :static && return StaticScheduler(; kwargs...)
+    s == :greedy && return GreedyScheduler(; kwargs...)
+    s == :serial && return SerialScheduler()
+    return scheduler_from_symbol(Val(s), kwargs...)
 end
 
 """

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -69,20 +69,15 @@ chunksplitter_mode(::Type{FixedCount}) = ChunkSplitters.Internals.FixedCount
 chunksplitter_mode(::Type{FixedSize}) = ChunkSplitters.Internals.FixedSize
 
 """
-    ChunkingArgs{C, S <: Split}(n::Int, size::Int, split::S)
-    ChunkingArgs(Sched::Type{<:Scheduler}, n::MaybeInteger, size::MaybeInteger, split::Union{Symbol, Split}; chunking)
+    ChunkingArgs{C, S <: Split}(n::Union{Int, Nothing}, size::Union{Int, Nothing}, minsize::Union{Int, Nothing}, split::S)
+    ChunkingArgs(Sched::Type{<:Scheduler}; n = nothing, size = nothing, minsize = nothing, split::Union{Symbol, Split}; chunking)
 
 Stores all the information needed for chunking. The type parameter `C` is the chunking mode
-(`NoChunking`, `FixedSize`, or `FixedCount`).
-
-`MaybeInteger` arguments are arguments that can be `NotGiven`. If it is the case, the
-constructor automatically throws errors or gives defaults values while taking into account
-the kind of scheduler (provided by `Sched`, e.g. `DynamicScheduler`). The `chunking` keyword
-argument is a boolean and if true, everything is skipped and `C = NoChunking`.
+(`NoChunking`, `FixedSize`, or `FixedCount`). The `chunking` keyword argument is a boolean
+and if true, everything is skipped and `C = NoChunking`.
 
 Once the object is created, use the `has_fieldname(object)` function (e.g. `has_size(object)`)
-to know if the field is effectively used, since it is no longer
-`NotGiven` for type stability.
+to know if the field is effectively used.
 """
 struct ChunkingArgs{C, S <: Split}
     n::Union{Int, Nothing}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -347,10 +347,10 @@ end;
                 nchunks = 2, chunksize = 4, chunking = false)) ==
                   OhMyThreads.Schedulers.NoChunking
             @test OhMyThreads.Schedulers.chunking_mode(sched(;
-                nchunks = -2, chunksize = -4, split = :whatever, chunking = false)) ==
+                nchunks = nothing, chunksize = nothing, split = :whatever, chunking = false)) ==
                   OhMyThreads.Schedulers.NoChunking
             @test OhMyThreads.Schedulers.chunking_enabled(sched(;
-                nchunks = -2, chunksize = -4, chunking = false)) == false
+                nchunks = nothing, chunksize = nothing, chunking = false)) == false
             @test OhMyThreads.Schedulers.chunking_enabled(sched(;
                 nchunks = 2, chunksize = 4, chunking = false)) == false
         else
@@ -369,8 +369,6 @@ end;
         @test OhMyThreads.Schedulers.chunking_enabled(sched(; chunksize = 2)) == true
         @test OhMyThreads.Schedulers.chunking_enabled(sched(; nchunks = 2)) == true
         @test_throws ArgumentError sched(; nchunks = 2, chunksize = 3)
-        @test_throws ArgumentError sched(; nchunks = 0, chunksize = 0)
-        @test_throws ArgumentError sched(; nchunks = -2, chunksize = -3)
         @test_throws ArgumentError sched(; nchunks = 2, split = :whatever)
 
         let scheduler = sched(; chunksize = 2, split = :batch)
@@ -781,11 +779,11 @@ if Threads.nthreads() > 1
                 sleep(rand()/10)
                 A
             end
-    
+
             @test f1() == 1:10
             @test f2() == 1:10
         end
-    
+
         let
             f1() = tmap(1:10) do i
                 A = i
@@ -797,27 +795,27 @@ if Threads.nthreads() > 1
                 sleep(rand()/10)
                 A
             end
-    
+
             @test_throws BoxedVariableError f1()
             @test f2() == 1:10
-    
+
             A = 1 # Cause spooky action-at-a-distance by making A outer-local to the whole let block!
         end
-    
+
         let
             A = 1
             f1() = tmap(1:10) do i
                 A = 1
             end
             @test_throws BoxedVariableError f1() == ones(10) # Throws even though the redefinition is 'harmless'
-    
+
             @allow_boxed_captures begin
                 f2() = tmap(1:10) do i
                     A = 1
                 end
                 @test f2() == ones(10)
             end
-    
+
             # Can nest allow and disallow because they're scoped values!
             function f3()
                 @disallow_boxed_captures begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ ChunkedGreedy(; kwargs...) = GreedyScheduler(; kwargs...)
                 SerialScheduler, ChunkedGreedy)
                 @testset for split in (Consecutive(), RoundRobin(), :consecutive, :roundrobin)
                     for nchunks in (1, 2, 6)
-                        for minchunksize ∈ (nothing, 1, 3)
+                        for minchunksize ∈ (-1, 1, 3)
                             if sched == GreedyScheduler
                                 scheduler = sched(; ntasks = nchunks, minchunksize)
                             elseif sched == DynamicScheduler{OhMyThreads.Schedulers.NoChunking}
@@ -67,7 +67,7 @@ ChunkedGreedy(; kwargs...) = GreedyScheduler(; kwargs...)
                                 @test tcollect(f.(itrs...); kwargs...) ~ map_f_itr
                             end
                         end
-                    end 
+                    end
                 end
             end
         end
@@ -393,7 +393,7 @@ end;
     @test tmapreduce(sin, +, 1:10000; chunking = false) ≈ res_tmr
     @test tmapreduce(sin, +, 1:10000; minchunksize=10) ≈ res_tmr
     @test tmapreduce(sin, +, 1:10; minchunksize=10) == mapreduce(sin, +, 1:10)
-    
+
     # scheduler isa Scheduler
     @test tmapreduce(sin, +, 1:10000; scheduler = StaticScheduler()) ≈ res_tmr
     @test_throws ArgumentError tmapreduce(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ ChunkedGreedy(; kwargs...) = GreedyScheduler(; kwargs...)
                 SerialScheduler, ChunkedGreedy)
                 @testset for split in (Consecutive(), RoundRobin(), :consecutive, :roundrobin)
                     for nchunks in (1, 2, 6)
-                        for minchunksize ∈ (-1, 1, 3)
+                        for minchunksize ∈ (nothing, 1, 3)
                             if sched == GreedyScheduler
                                 scheduler = sched(; ntasks = nchunks, minchunksize)
                             elseif sched == DynamicScheduler{OhMyThreads.Schedulers.NoChunking}


### PR DESCRIPTION
Now that we can completely skip the threading part when there is a single chunk, it would be good to get as close as possible to `mapreduce` (in performance) when we are in this case.

Base  `mapreduce`:
```julia
julia> @btime mapreduce(sin, +, $(1:10))
  65.331 ns (0 allocations: 0 bytes)
```

before:
```julia
julia> @btime tmapreduce(sin, +, $(1:10); minchunksize = 100)
  101.726 ns (3 allocations: 96 bytes)
```

With this PR:
```julia
julia> @btime tmapreduce(sin, +, $(1:10); minchunksize = 100)
  67.880 ns (0 allocations: 0 bytes)
```
This is done by changing the types to be "is bits" (in this case, i.e., not heap-allocated):

- `minsize` is negative instead of `nothing` in `ChunkingArgs`
- `threadpool` is a compile time symbol in `DynamicScheduler`. So `sched.threadpool` no longer works and is replaced by `threadpool(sched)`.

By doing some profiling, we can find that the small gap that remains with `mapreduce` is the call to `div` which allows to calculate the number of chunks. So it seems difficult to go further than that.


There is still an issue if we pass the scheduler as a symbol:
```julia
julia> @btime tmapreduce(sin, +, $(1:10); scheduler = :dynamic, minchunksize = 100)
  177.354 ns (5 allocations: 144 bytes)
```

This is because the symbol is a runtime variable. So to bind it to its associated type, there will necessarily be type instability. Sometimes Julia manages to do this by taking the symbol as a constant, but it seems rather random. There are several solutions:

```julia
julia> @btime tmapreduce(sin, +, $(1:10); scheduler = Val(:dynamic), minchunksize = 100)
  67.880 ns (0 allocations: 0 bytes)

julia> @btime tmapreduce(sin, +, $(1:10); scheduler = DynamicScheduler(minchunksize = 100))
  67.887 ns (0 allocations: 0 bytes)
```

One could go even further and implement the scheduler as a positional argument instead of a keyword one, i.e. `tmapreduce(sin, +, 1:10, DynamicScheduler(minchunksize = 100))`, but i am not really sure about that. 