### PR TITLE
fix: tmap with chunks gives UndefVarError

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OhMyThreads"
 uuid = "67456a42-1dca-4109-a031-0a68de7e3ad5"
 authors = ["Carsten Bauer <mail@carstenbauer.eu>", "Mason Protter <mason.protter@icloud.com>"]
-version = "0.8.3"
+version = "0.8.4"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -436,7 +436,7 @@ function tmap(f,
         if chunking_enabled(_scheduler)
             if _scheduler isa DynamicScheduler
                 _scheduler = DynamicScheduler(;
-                    threadpool = threadpool(_scheduler),
+                    threadpool = get_threadpool(_scheduler),
                     chunking = false)
             elseif _scheduler isa StaticScheduler
                 _scheduler = StaticScheduler(; chunking = false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,7 +78,9 @@ end;
     x = rand(100)
     chnks = OhMyThreads.index_chunks(x; n = Threads.nthreads())
     for scheduler in (
-        DynamicScheduler(; chunking = false), StaticScheduler(; chunking = false))
+        DynamicScheduler(),
+        DynamicScheduler(; chunking = false),
+        StaticScheduler(; chunking = false))
         @testset "$scheduler" begin
             @test tmap(x -> sin.(x), chnks; scheduler) ≈ map(x -> sin.(x), chnks)
             @test tmapreduce(x -> sin.(x), vcat, chnks; scheduler) ≈


### PR DESCRIPTION
# Context
Doing a simple `tmap(identity, chunks(1:10; n=2))` results in a UndefVarError. 

# Fix
Reason for this is a simple typo. I also amended the test to cover this case.

Note: I ran JuliaFormatter on the code base but that resulted in a couple of additional formatting changes. For this PR, I kept only the places I changed and dropped the additional formatting changes.

Fixes #159 