### PR TITLE
Allow `SerialScheduler` to accept and ignore arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 OhMyThreads.jl Changelog
 =========================
 
+Unreleased
+------------
+- ![Enhancement][badge-enhancement] `SerialScheduler` now accepts and ignores arguments passed to it to make switching schedulers easier [#162][gh-pr-162].
+
 Version 0.8.3
 ------------
 - ![Enhancement][badge-enhancement] The overhead of `tmapreduce` in the serial case was reduced a bit. Sentinel values in scheduler kwarg internals were replaced by `nothing` [#148][gh-pr-148]

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -379,8 +379,14 @@ end
 A scheduler for turning off any multithreading and running the code in serial. It aims to
 make parallel functions like, e.g., `tmapreduce(sin, +, 1:100)` behave like their serial
 counterparts, e.g., `mapreduce(sin, +, 1:100)`.
+
+Note that `SerialScheduler` has no arguments and will ignore any that are passed
+to it. This is to make it easier to switch to the serial scheduler without
+having to change the rest of the code.
 """
 struct SerialScheduler <: Scheduler
+    # Dummy constructor to allow ignoring settings for other schedulers
+    SerialScheduler(; _...) = new()
 end
 from_symbol(::Val{:serial}) = SerialScheduler
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,7 +34,7 @@ ChunkedGreedy(; kwargs...) = GreedyScheduler(; kwargs...)
                             elseif sched == DynamicScheduler{OhMyThreads.Schedulers.NoChunking}
                                 scheduler = DynamicScheduler(; chunking = false)
                             elseif sched == SerialScheduler
-                                scheduler = SerialScheduler()
+                                scheduler = SerialScheduler(; nchunks)
                             else
                                 scheduler = sched(; nchunks, split, minchunksize)
                             end
@@ -194,11 +194,6 @@ end;
     end) |> isnothing
     @test_throws ArgumentError @tasks(for i in 1:3
         @set scheduler = DynamicScheduler()
-        @set chunking = false
-        i
-    end)
-    @test_throws MethodError @tasks(for i in 1:3
-        @set scheduler = :serial
         @set chunking = false
         i
     end)


### PR DESCRIPTION
I was switching schedulers a bit recently during development and would've liked to have this.