### PR TITLE
add ProgressMeter extension module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ OhMyThreads.jl Changelog
 Unreleased
 ------------
 - ![Enhancement][badge-enhancement] `SerialScheduler` now accepts and ignores arguments passed to it to make switching schedulers easier [#162][gh-pr-162].
+- ![Enhancement][badge-enhancement] `tmap`, `tmap!`, `tforeach`, `tmapreduce`, `treducemap`, and `treduce` are now compatible with [ProgressMeter.jl](https://github.com/timholy/ProgressMeter.jl), so you can do e.g. `@showprogress tmap(...)`[#164][gh-pr-164].
 
 Version 0.8.3
 ------------

--- a/Project.toml
+++ b/Project.toml
@@ -12,15 +12,18 @@ TaskLocalValues = "ed4db957-447d-4319-bfb6-7fa9ae7ecf34"
 
 [weakdeps]
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 
 [extensions]
 MarkdownExt = "Markdown"
+ProgressMeterExt = "ProgressMeter"
 
 [compat]
 Aqua = "0.8"
 BangBang = "0.3.40, 0.4"
 ChunkSplitters = "3.1"
 Markdown = "1"
+ProgressMeter = "1.10"
 ScopedValues = "1.3"
 StableTasks = "0.1.5"
 TaskLocalValues = "0.1"

--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,8 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Aqua"]
+test = ["Test", "Aqua", "ProgressMeter"]

--- a/ext/ProgressMeterExt.jl
+++ b/ext/ProgressMeterExt.jl
@@ -1,0 +1,14 @@
+module ProgressMeterExt
+
+using OhMyThreads: tmap, tmap!, tforeach, tmapreduce, treducemap, treduce
+using ProgressMeter: ProgressMeter, ncalls_map, ncalls_reduce
+
+ProgressMeter.ncalls(::typeof(tmap), ::Function, args...) = ncalls_map(args...)
+ProgressMeter.ncalls(::typeof(tmap), ::Function, ::Type, args...) = ncalls_map(args...)
+ProgressMeter.ncalls(::typeof(tmap!), ::Function, args...) = ncalls_map(args...)
+ProgressMeter.ncalls(::typeof(tforeach), ::Function, args...) = ncalls_map(args...)
+ProgressMeter.ncalls(::typeof(tmapreduce), ::Function, ::Function, args...) = ncalls_map(args...)
+ProgressMeter.ncalls(::typeof(treducemap), ::Function, ::Function, args...) = ncalls_map(args...)
+ProgressMeter.ncalls(::typeof(treduce), ::Function, arg) = ncalls_reduce(arg)
+
+end

--- a/test/ProgressMeterExt.jl
+++ b/test/ProgressMeterExt.jl
@@ -1,0 +1,49 @@
+using Test, OhMyThreads, ProgressMeter
+
+@testset "ProgressMeterExt" begin
+    data = rand(1000)
+
+    @testset "tmap" begin
+        map_result = map(sin, data)
+        @testset for scheduler in (:dynamic, :static, :serial)
+            @test (@showprogress dt=0 desc="tmap ($scheduler)" tmap(sin, data; scheduler)) ≈ map_result
+        end
+        # greedy requires explicit output type
+        @test (@showprogress dt=0 desc="tmap (greedy)" tmap(sin, Float64, data; scheduler = :greedy)) ≈ map_result
+    end
+
+    @testset "tmap!" begin
+        @testset for scheduler in (:dynamic, :static, :greedy, :serial)
+            out = similar(data)
+            @showprogress dt=0 desc="tmap! ($scheduler)" tmap!(sin, out, data; scheduler)
+            @test out ≈ map(sin, data)
+        end
+    end
+
+    @testset "tforeach" begin
+        @testset for scheduler in (:dynamic, :static, :greedy, :serial)
+            @test (@showprogress dt=0 desc="tforeach ($scheduler)" tforeach(sin, data; scheduler)) |> isnothing
+        end
+    end
+
+    @testset "tmapreduce" begin
+        mapreduce_result = mapreduce(sin, +, data)
+        @testset for scheduler in (:dynamic, :static, :greedy, :serial)
+            @test (@showprogress dt=0 desc="tmapreduce ($scheduler)" tmapreduce(sin, +, data; scheduler)) ≈ mapreduce_result
+        end
+    end
+
+    @testset "treducemap" begin
+        mapreduce_result = mapreduce(sin, +, data)
+        @testset for scheduler in (:dynamic, :static, :greedy, :serial)
+            @test (@showprogress dt=0 desc="treducemap ($scheduler)" treducemap(+, sin, data; scheduler)) ≈ mapreduce_result
+        end
+    end
+
+    @testset "treduce" begin
+        reduce_result = reduce(+, data)
+        @testset for scheduler in (:dynamic, :static, :greedy, :serial)
+            @test (@showprogress dt=0 desc="treduce ($scheduler)" treduce(+, data; scheduler)) ≈ reduce_result
+        end
+    end
+end

--- a/test/ProgressMeterExt.jl
+++ b/test/ProgressMeterExt.jl
@@ -6,44 +6,44 @@ using Test, OhMyThreads, ProgressMeter
     @testset "tmap" begin
         map_result = map(sin, data)
         @testset for scheduler in (:dynamic, :static, :serial)
-            @test (@showprogress dt=0 desc="tmap ($scheduler)" tmap(sin, data; scheduler)) ≈ map_result
+            @test (@showprogress desc="tmap ($scheduler)" tmap(sin, data; scheduler)) ≈ map_result
         end
         # greedy requires explicit output type
-        @test (@showprogress dt=0 desc="tmap (greedy)" tmap(sin, Float64, data; scheduler = :greedy)) ≈ map_result
+        @test (@showprogress desc="tmap (greedy)" tmap(sin, Float64, data; scheduler = :greedy)) ≈ map_result
     end
 
     @testset "tmap!" begin
         @testset for scheduler in (:dynamic, :static, :greedy, :serial)
             out = similar(data)
-            @showprogress dt=0 desc="tmap! ($scheduler)" tmap!(sin, out, data; scheduler)
+            @showprogress desc="tmap! ($scheduler)" tmap!(sin, out, data; scheduler)
             @test out ≈ map(sin, data)
         end
     end
 
     @testset "tforeach" begin
         @testset for scheduler in (:dynamic, :static, :greedy, :serial)
-            @test (@showprogress dt=0 desc="tforeach ($scheduler)" tforeach(sin, data; scheduler)) |> isnothing
+            @test (@showprogress desc="tforeach ($scheduler)" tforeach(sin, data; scheduler)) |> isnothing
         end
     end
 
     @testset "tmapreduce" begin
         mapreduce_result = mapreduce(sin, +, data)
         @testset for scheduler in (:dynamic, :static, :greedy, :serial)
-            @test (@showprogress dt=0 desc="tmapreduce ($scheduler)" tmapreduce(sin, +, data; scheduler)) ≈ mapreduce_result
+            @test (@showprogress desc="tmapreduce ($scheduler)" tmapreduce(sin, +, data; scheduler)) ≈ mapreduce_result
         end
     end
 
     @testset "treducemap" begin
         mapreduce_result = mapreduce(sin, +, data)
         @testset for scheduler in (:dynamic, :static, :greedy, :serial)
-            @test (@showprogress dt=0 desc="treducemap ($scheduler)" treducemap(+, sin, data; scheduler)) ≈ mapreduce_result
+            @test (@showprogress desc="treducemap ($scheduler)" treducemap(+, sin, data; scheduler)) ≈ mapreduce_result
         end
     end
 
     @testset "treduce" begin
         reduce_result = reduce(+, data)
         @testset for scheduler in (:dynamic, :static, :greedy, :serial)
-            @test (@showprogress dt=0 desc="treduce ($scheduler)" treduce(+, data; scheduler)) ≈ reduce_result
+            @test (@showprogress desc="treduce ($scheduler)" treduce(+, data; scheduler)) ≈ reduce_result
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -840,3 +840,5 @@ if Threads.nthreads() > 1
 end
 
 # Todo way more testing, and easier tests to deal with
+
+include("ProgressMeterExt.jl")


### PR DESCRIPTION
Fixes https://github.com/JuliaFolds2/OhMyThreads.jl/issues/59

E.g.
```
julia> using ProgressMeter, OhMyThreads

julia> @showprogress tmap(i -> (sleep(0.1); i^2), 1:10)
Progress: 100%|██████████████████| Time: 0:00:00
10-element Vector{Int64}:
...
```

I have a test file I used that basically does that command for everything, but I didn't commit since it didn't feel right, but let me know. 

Note the use of `::Function` (rather than `::Callable`) just matches what ProgressMeter does to avoid any ambiguities. 